### PR TITLE
fix: Database Race Condition and False No-Answer Notifications

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Connect',
-    'version': '1.0.8',
+    'version': '1.0.9',
     'author': 'Oduist',
     'maintainer': 'Oduist',
     'live_test_url': 'https://connect-demo-18.oduist.com/',

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -200,10 +200,10 @@ class Call(models.Model):
         # Set called from 2nd call leg for click2call external calls.
         if channel.parent_channel.technical_direction == 'outbound-api':
             channel.call.called = channel.called_number
-        # Set called users
-        if channel.called_user:
+        # Set called users (avoid duplicates to prevent serialization errors)
+        if channel.called_user and channel.called_user not in channel.call.called_users:
             channel.call.called_users = [(4, channel.called_user.id)]
-        if channel.called_pbx_user:
+        if channel.called_pbx_user and channel.called_pbx_user not in channel.call.called_pbx_users:
             channel.call.called_pbx_users = [(4, channel.called_pbx_user.id)]
         # Set the answered user
         if channel.call.status == 'completed':
@@ -218,10 +218,17 @@ class Call(models.Model):
                 params.get('To').startswith('sip:')):
             # Desktop notification only for SIP calls.
             channel.connect_notify()
-        # Register call when the last channel closes.
-        latest_channel = channel.call.channels.sorted(key='id', reverse=True)[0]
-        if channel == latest_channel and params.get('CallStatus') in CALL_END_STATUSES:
-            self.register_call(channel, params)
+        # Register call when ALL channels have ended (not just the latest one).
+        # This prevents false "no-answer" notifications when one dial attempt fails
+        # but another is still active.
+        if params.get('CallStatus') in CALL_END_STATUSES:
+            # Check if all channels have ended
+            all_channels_ended = all(
+                ch.status in CALL_END_STATUSES
+                for ch in channel.call.channels
+            )
+            if all_channels_ended:
+                self.register_call(channel, params)
             # Fetch call price if enabled in settings
             if self.env['connect.settings'].sudo().get_param('fetch_call_prices'):
                 self.save_call_price(channel.call, params)


### PR DESCRIPTION
## Summary

This PR fixes two critical issues in the call handling logic that occurred when Twilio's `<Dial>` creates simultaneous `<Client>` and `<Sip>` channels:

1. **Database serialization errors** caused by concurrent webhook requests attempting to modify the same user relationship
2. **False "no-answer" notifications** sent when one channel fails while another is still active

---

## Issues Fixed

### Issue 1: Database Serialization Error

**Location:** `/workspace/HarrisonConsulting/connect_addons/connect/models/call.py:204-207`

**Root Cause:**  
When Twilio's `<Dial>` creates both `<Client>` and `<Sip>` channels simultaneously, both webhooks attempted to add the same user to `called_users` at the same time, resulting in a database race condition.

**Fix Applied:**
```python
# Before (caused race condition):
channel.call.called_users = [(4, channel.called_user.id)]

# After (checks for duplicates first):
if channel.called_user and channel.called_user not in channel.call.called_users:
    channel.call.called_users = [(4, channel.called_user.id)]
```

---

### Issue 2: False "No-Answer" Notification

**Location:** `/workspace/HarrisonConsulting/connect_addons/connect/models/call.py:221-231`

**Root Cause:**  
`register_call()` was triggered when the latest channel ended, even if other channels were still active.

**Timeline:**
1. Client dial (CH-1721) fails with "no-answer" → becomes latest channel → triggers `register_call()`
2. Notification sent: "No-answer incoming call at..."
3. SIP dial (CH-1723) still ringing, will answer successfully later

**Fix Applied:**
```python
# Before (triggered on latest channel ending):
latest_channel = channel.call.channels.sorted(key='id', reverse=True)[0]
if channel == latest_channel and params.get('CallStatus') in CALL_END_STATUSES:
    self.register_call(channel, params)

# After (only triggers when ALL channels end):
if params.get('CallStatus') in CALL_END_STATUSES:
    all_channels_ended = all(
        ch.status in CALL_END_STATUSES
        for ch in channel.call.channels
    )
    if all_channels_ended:
        self.register_call(channel, params)
```

---

## Expected Behavior

With these fixes, the next incoming call will:

- ✅ **No serialization errors** in logs
- ✅ **No "missed call" notification** if you answer via SIP after Client dial times out
- ✅ **Correct final call status** reflects the successful channel (SIP), not the failed one (Client)

The fixes ensure that simultaneous dial attempts don't interfere with each other and that notifications only fire when the call truly ends across all channels.