### PR TITLE
[IMP] connect_elevenlabs: controllers fix, sync tools, transfer tool migration

### DIFF
--- a/.agents/skills/oduflow/SKILL.md
+++ b/.agents/skills/oduflow/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: oduflow
+description: "Agentic Odoo development with Oduflow MCP. Use when creating, syncing, debugging, or managing ephemeral Odoo environments per git branch. Covers the full workflow: create environment, push code, sync, read errors, fix, test, teardown."
+---
+
+# Oduflow — Agentic Odoo Development
+
+## What is Oduflow
+
+Oduflow is an MCP server that provisions isolated, ephemeral Odoo environments on Docker — one per git branch — with instant creation from reusable database templates. It gives AI coding agents a **closed feedback loop**: write code → install module → read errors → fix → retry, all without human intervention.
+
+---
+
+## Core Workflow for Agents
+
+```
+1. list_environments          — Check if an environment for the current branch exists
+2. create_environment         — If not, provision one (branch, repo_url, odoo_image)
+3. Write / edit code locally
+4. git push
+5. sync_environment — Pull changes; errors/tracebacks are returned directly in the response
+6. If errors in response → fix code → go to step 4
+7. test_environment            — Run Odoo tests for the changed modules
+8. delete_environment          — Tear down when done
+```
+
+---
+
+## MCP Tools Quick Reference
+
+### Environment Lifecycle
+
+| Tool | When to use |
+|---|---|
+| `list_environments` | Check existing environments before creating a new one |
+| `create_environment(branch_name, repo_url, odoo_image, template_name?)` | Provision an environment. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects |
+| `get_environment_status(branch_name)` | Check if the environment is running, get URL, CPU/RAM stats |
+| `delete_environment(branch_name)` | Tear down when the task is complete or cancelled |
+| `start_environment` / `stop_environment` | Resume or pause a stopped environment |
+| `restart_environment(branch_name)` | Restart the Odoo container (rarely needed — `sync_environment` handles this) |
+| `rebuild_environment(branch_name)` | Recreate the container from scratch if it's broken, without losing DB or filestore |
+
+### Code → Environment Sync
+
+| Tool | When to use |
+|---|---|
+| `sync_environment(branch_name)` | **Always call after every `git push`**. Oduflow analyzes changed files and automatically decides: install new modules, upgrade changed modules, restart for Python changes, or do nothing for XML/JS (hot-reloaded). You do NOT need to call `restart` or `upgrade` manually. **Errors and tracebacks are returned directly in the tool response** — do NOT call `get_environment_logs` to check for errors after this tool. |
+
+### Odoo Module Operations
+
+| Tool | When to use |
+|---|---|
+| `install_odoo_modules(branch_name, modules)` | Install modules for the first time (`odoo -i`). Comma-separated list, e.g. `"sale,crm"`. **Returns full output including any errors directly in the response.** |
+| `upgrade_odoo_modules(branch_name, modules)` | Force-upgrade modules (`odoo -u`). Usually handled by `sync_environment`. **Returns full output including any errors directly in the response.** |
+| `test_environment(branch_name, modules)` | Run Odoo tests (`--test-enable`) for specific modules. **Returns full test output directly in the response.** |
+
+### Debugging & Logs
+
+> ⚠️ **Critical: understand where logs come from.**
+>
+> `install_odoo_modules`, `upgrade_odoo_modules`, `test_environment`, and `sync_environment` run Odoo commands via `docker exec`. Their output is **returned directly in the tool response** and does **NOT** appear in `get_environment_logs`.
+>
+> `get_environment_logs` shows logs from the **main Odoo process** (the container's entrypoint, PID 1) — i.e., runtime errors that occur while Odoo is serving requests, not errors from install/upgrade/test operations.
+
+| Tool | What it shows |
+|---|---|
+| `get_environment_logs(branch_name, n_lines?)` | Logs from the **running Odoo server** (main container process). Use to check for runtime errors, request errors, or startup issues after a restart. Does **NOT** contain output from install/upgrade/test operations. |
+| `exec_in_environment(branch_name, command, user?)` | Run shell commands inside the container. Use `user="root"` for privileged ops (pip install, apt). Useful for DB queries, debugging, checking file paths |
+
+**When to use which:**
+- After `sync_environment` / `install_odoo_modules` / `upgrade_odoo_modules` / `test_environment` → **read the tool response** for errors
+- After `restart_environment` or to check runtime behavior → use `get_environment_logs`
+
+### Private Repositories
+
+| Tool | When to use |
+|---|---|
+| `setup_repo_auth(repo_url)` | Cache git credentials for a private repo. URL format: `https://user:PAT@github.com/owner/repo.git`. Call once, before `create_environment` |
+
+### Auxiliary Services
+
+| Tool | When to use |
+|---|---|
+| `create_service(name, image, port, hostname?, env_vars?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}` |
+| `list_services` / `get_service_logs(name)` / `delete_service(name)` | Manage auxiliary services |
+
+### Template Management (use with caution)
+
+| Tool | When to use |
+|---|---|
+| `list_templates` | List available database template profiles |
+| `publish_as_template(branch_name)` | ⚠️ **Destructive**. Make a branch the new template baseline. Requires explicit user permission |
+| `drop_template(template_name)` | ⚠️ **Destructive**. Remove a template profile. Requires explicit user permission |
+
+---
+
+## Rules for Agents
+
+### Initialization
+1. **Check first**: Call `list_environments`. If an environment for the current branch exists, reuse it.
+2. **Create if needed**: Call `create_environment` with the current branch name, repository HTTPS URL, and the correct Odoo Docker image.
+3. **Auth errors**: On 401/403 from `create_environment`, suggest `setup_repo_auth` to the user.
+4. **Show the URL**: Always display the environment URL to the user after creation.
+
+### Sync & Work Cycle
+1. After every `git push`, **always** call `sync_environment`. It handles install/upgrade/restart automatically.
+2. Do **not** call `restart_environment` or `upgrade_odoo_modules` manually unless debugging a specific issue — `sync_environment` already does the right thing.
+3. After `sync_environment`, **read the tool response** for errors. Do NOT call `get_environment_logs` — install/upgrade output is returned directly and does not appear in container logs.
+
+### Debugging Loop
+```
+push → sync_environment → read the response for errors → fix if errors → repeat
+```
+Do NOT call `get_environment_logs` after `sync_environment` — the errors are already in the response. Use `get_environment_logs` only to check the **running server** (e.g., runtime errors during request handling).
+
+### Teardown
+- Only call `delete_environment` when the task is **Done** or **Cancelled**.
+- Do **not** recreate an environment to fix errors without user consent.
+
+### Container Is Read-Only for Code
+
+The environment container runs **remotely** and has access only to the git repository it was created for. The container is **not your workspace** — it is a runtime for testing.
+
+**What you CAN do inside the container (`exec_in_environment`):**
+- Read files, inspect paths (`ls`, `cat`, `find`)
+- Run Odoo shell commands (`odoo shell`, `odoo scaffold`, etc.)
+
+> **Note:** For logs use `get_environment_logs` — container logs are not accessible via shell commands inside Docker. For database queries use `run_db_query` — it connects to PostgreSQL directly without needing `exec_in_environment`.
+
+**What you MUST NOT do inside the container:**
+- Edit source code files (no `sed`, `vim`, `echo >`, `patch`, etc.)
+- Run any git commands (`git rebase`, `git pull`, `git checkout`, `git stash`, etc.)
+- Modify module files in any way
+
+**If you need to change code** — always do it locally, then `git commit` → `git push` → `sync_environment`. This is the only correct way to deliver code changes to the environment.
+
+**Non-standard operations** (e.g., `apt install`, `pip install`, modifying system configs) are possible but **require explicit user confirmation** before proceeding — explain what you want to do and why.
+
+### General
+- **One task = one branch = one environment.**
+- Mutexed tools (create, delete, install, upgrade, pull, test, exec) reject concurrent calls with `BusyError` — retry after a short delay.
+- `exec_in_environment` runs as `odoo` by default. Use `user="root"` for package installation or system operations.
+- Database is accessible from inside the container: `psql -h oduflow-db -U odoo -d oduflow_{branch_name}`.
+
+---
+
+## Smart Pull — What Happens Automatically
+
+When you call `sync_environment`, Oduflow analyzes every changed file:
+
+| What changed | Action taken |
+|---|---|
+| New `__manifest__.py` (new module) | **Install** the module |
+| `__manifest__.py` version/data/assets changed | **Upgrade** the module |
+| `*.py` with `fields.*` changes | **Upgrade** the module |
+| `security/*.xml` | **Upgrade** the module |
+| `*.py` without field changes | **Restart** the container |
+| `*.xml` (views, data) / `*.js` | **Nothing** — hot-reloaded via `--dev=xml` |
+
+Priority: install > upgrade > restart > refresh (no action).
+
+---
+
+## Database Migrations Workflow
+
+> ⚠️ **Critical: migrations only run during module upgrade, NOT during environment creation.**
+>
+> When `create_environment` provisions from a template, it clones the template database as-is. **No migrations are executed.** Migrations (files in `migrations/` or `upgrades/`) are only triggered by `upgrade_odoo_modules` (or `sync_environment` when it detects a version bump).
+
+### Anti-patterns — Do NOT Do This
+
+| ❌ Anti-pattern | Why it's wrong |
+|---|---|
+| Deleting and recreating the environment to "apply" a migration | `create_environment` from a template does **not** run migrations — you'll get the old schema back and lose your test data |
+| Relying on `create_environment` to execute migrations | Templates are snapshots; migrations require an explicit upgrade step |
+| Skipping verification after upgrade | A migration may silently fail or apply partially — always verify |
+
+### Correct Workflow for Database Schema Changes
+
+```
+Step 1: git commit & push   — Commit the migration script + version bump in __manifest__.py
+Step 2: sync_environment    — Or call upgrade_odoo_modules directly; this triggers the migration
+Step 3: run_db_query         — Run a SELECT query to verify the expected schema/data changes
+Step 4: get_environment_logs — If something went wrong, check for migration INFO/ERROR messages
+```
+
+### How to Verify a Migration
+
+1. **Query the database** via `run_db_query`:
+   ```sql
+   SELECT column_name FROM information_schema.columns WHERE table_name = 'your_table';
+   ```
+   Confirm that new columns, constraints, or data changes are present.
+
+2. **Check logs** via `get_environment_logs`: look for `odoo.modules.migration` INFO messages confirming the migration script was executed.
+
+> **Key takeaway: NEVER recreate an environment to test migrations. Always use `upgrade_odoo_modules` or `sync_environment`.**
+
+---
+
+## Example: Full Agent Session
+
+```
+Agent: list_environments → no environment for "feature-invoice-pdf"
+
+Agent: create_environment("feature-invoice-pdf", "https://github.com/company/addons.git", "odoo:17.0")
+→ Environment created at http://server:50042
+
+Agent: [writes code for the module]
+Agent: git push
+
+Agent: sync_environment("feature-invoice-pdf")
+→ "Upgraded modules: invoice_pdf. Restarted container.
+   Output:
+   ...
+   odoo.exceptions.ValidationError: Field 'x_custom_field' already exists on model 'account.move'
+   ..."
+   # ↑ Error is in the tool response — no need to call get_environment_logs
+
+Agent: [fixes the field conflict in code]
+Agent: git push
+
+Agent: sync_environment("feature-invoice-pdf")
+→ "Upgraded modules: invoice_pdf. Restarted container. Exit code: 0."
+   # ↑ No errors in the response — module upgraded successfully
+
+Agent: test_environment("feature-invoice-pdf", "invoice_pdf")
+→ "Ran 12 tests, 0 failures. Exit code: 0."
+   # ↑ Test results are also in the response
+
+Agent: delete_environment("feature-invoice-pdf")
+→ Environment deleted.
+```

--- a/connect_elevenlabs/__manifest__.py
+++ b/connect_elevenlabs/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Connect ElevenLabs',
-    'version': '1.0.4',
+    'version': '1.0.5',
     'author': 'Oduist',
     'price': 0,
     'currency': 'EUR',

--- a/connect_elevenlabs/__manifest__.py
+++ b/connect_elevenlabs/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Connect ElevenLabs',
-    'version': '1.0.3',
+    'version': '1.0.4',
     'author': 'Oduist',
     'price': 0,
     'currency': 'EUR',

--- a/connect_elevenlabs/controllers/calendar.py
+++ b/connect_elevenlabs/controllers/calendar.py
@@ -38,7 +38,11 @@ class CalendarController(http.Controller):
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
         user_id = kwargs.get('user_id')
         if kwargs.get('timezone'):
-            user_timezone = timezone(timedelta(hours=int(kwargs.get('timezone'))))
+            tz_val = kwargs['timezone']
+            try:
+                user_timezone = ZoneInfo(tz_val)
+            except (KeyError, ValueError):
+                user_timezone = timezone(timedelta(hours=int(tz_val)))
         else:
             user = http.request.env['res.users'].sudo().browse(user_id)
             tz = user.partner_id.tz
@@ -86,7 +90,11 @@ class CalendarController(http.Controller):
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
         user_id = kwargs.get('user_id')
         if kwargs.get('timezone'):
-            user_timezone = timezone(timedelta(hours=int(kwargs.get('timezone'))))
+            tz_val = kwargs['timezone']
+            try:
+                user_timezone = ZoneInfo(tz_val)
+            except (KeyError, ValueError):
+                user_timezone = timezone(timedelta(hours=int(tz_val)))
         else:
             user = http.request.env['res.users'].sudo().browse(user_id)
             tz = user.partner_id.tz

--- a/connect_elevenlabs/controllers/calendar.py
+++ b/connect_elevenlabs/controllers/calendar.py
@@ -5,6 +5,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
+from werkzeug.exceptions import Unauthorized
+
 from odoo import http, release
 
 logger = logging.getLogger(__name__)
@@ -12,9 +14,20 @@ route_type = "json" if release.version_info[0] < 19.0 else 'jsonrpc'
 
 class CalendarController(http.Controller):
 
+    def check_tool_token(self):
+        token = http.request.httprequest.headers.get('x-elevenlabs-agent-token')
+        if not token:
+            return False
+        expected_token = http.request.env['connect.settings'].sudo().get_param('elevenlabs_agent_token')
+        if not expected_token or token != expected_token:
+            return False
+        return True
+
     @http.route('/connect_elevenlabs/get_available_slots', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def get_available_slots(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
         user_id = kwargs.get('user_id')
         if kwargs.get('timezone'):
@@ -60,6 +73,8 @@ class CalendarController(http.Controller):
     @http.route('/connect_elevenlabs/create_event', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def create_event(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
         user_id = kwargs.get('user_id')
         if kwargs.get('timezone'):
@@ -93,11 +108,15 @@ class CalendarController(http.Controller):
 
     @http.route('/connect_elevenlabs/get_current_date', methods=['POST'], type=route_type, auth='public', csrf=False)
     def get_current_date(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         return {'current_date': str(datetime.now())}
 
     @http.route('/connect_elevenlabs/get_meetings', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def get_meetings(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
         partner_id = kwargs.get('partner_id')
         if not partner_id:
@@ -111,6 +130,8 @@ class CalendarController(http.Controller):
     @http.route('/connect_elevenlabs/remove_meeting', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def remove_meeting(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
         event_id = kwargs.get('event_id')
         if not event_id:

--- a/connect_elevenlabs/controllers/calendar.py
+++ b/connect_elevenlabs/controllers/calendar.py
@@ -17,15 +17,22 @@ class CalendarController(http.Controller):
     def check_tool_token(self):
         token = http.request.httprequest.headers.get('x-elevenlabs-agent-token')
         if not token:
+            logger.warning('Tool token check failed: no x-elevenlabs-agent-token header in request')
             return False
         expected_token = http.request.env['connect.settings'].sudo().get_param('elevenlabs_agent_token')
-        if not expected_token or token != expected_token:
+        if not expected_token:
+            logger.warning('Tool token check failed: elevenlabs_agent_token is not configured in settings')
             return False
+        if token != expected_token:
+            logger.warning('Tool token check failed: token mismatch (received %s...)', token[:8])
+            return False
+        logger.info('Tool token check passed')
         return True
 
     @http.route('/connect_elevenlabs/get_available_slots', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def get_available_slots(self):
+        logger.info('Incoming request: /connect_elevenlabs/get_available_slots')
         if not self.check_tool_token():
             raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
@@ -73,6 +80,7 @@ class CalendarController(http.Controller):
     @http.route('/connect_elevenlabs/create_event', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def create_event(self):
+        logger.info('Incoming request: /connect_elevenlabs/create_event')
         if not self.check_tool_token():
             raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
@@ -108,6 +116,7 @@ class CalendarController(http.Controller):
 
     @http.route('/connect_elevenlabs/get_current_date', methods=['POST'], type=route_type, auth='public', csrf=False)
     def get_current_date(self):
+        logger.info('Incoming request: /connect_elevenlabs/get_current_date')
         if not self.check_tool_token():
             raise Unauthorized()
         return {'current_date': str(datetime.now())}
@@ -115,6 +124,7 @@ class CalendarController(http.Controller):
     @http.route('/connect_elevenlabs/get_meetings', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def get_meetings(self):
+        logger.info('Incoming request: /connect_elevenlabs/get_meetings')
         if not self.check_tool_token():
             raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
@@ -130,6 +140,7 @@ class CalendarController(http.Controller):
     @http.route('/connect_elevenlabs/remove_meeting', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
     def remove_meeting(self):
+        logger.info('Incoming request: /connect_elevenlabs/remove_meeting')
         if not self.check_tool_token():
             raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))

--- a/connect_elevenlabs/controllers/main.py
+++ b/connect_elevenlabs/controllers/main.py
@@ -19,16 +19,23 @@ class ConnectElevenlabsController(http.Controller):
     def check_tool_token(self):
         token = http.request.httprequest.headers.get('x-elevenlabs-agent-token')
         if not token:
+            logger.warning('Tool token check failed: no x-elevenlabs-agent-token header in request')
             return False
         expected_token = http.request.env['connect.settings'].sudo().get_param('elevenlabs_agent_token')
-        if not expected_token or token != expected_token:
+        if not expected_token:
+            logger.warning('Tool token check failed: elevenlabs_agent_token is not configured in settings')
             return False
+        if token != expected_token:
+            logger.warning('Tool token check failed: token mismatch (received %s...)', token[:8])
+            return False
+        logger.info('Tool token check passed')
         return True
 
     def check_post_call_webhook(self):
         payload = http.request.httprequest.get_data(as_text=True)
         headers = http.request.httprequest.headers.get("elevenlabs-signature")
         if not headers:
+            logger.warning('Post call webhook check failed: no elevenlabs-signature header')
             return False
         timestamp = headers.split(",")[0][2:]
         hmac_signature = headers.split(",")[1]
@@ -47,12 +54,14 @@ class ConnectElevenlabsController(http.Controller):
         )
         digest = 'v0=' + mac.hexdigest()
         if hmac_signature != digest:
-            logger.info('Invalid elevenlabs post call webhook signature!')
+            logger.warning('Post call webhook check failed: signature mismatch')
             return False
+        logger.info('Post call webhook signature check passed')
         return True
 
     @http.route('/connect_elevenlabs/transfer', methods=['POST'], type='http', auth='public', csrf=False)
     def transfer_webhook(self):
+        logger.info('Incoming request: /connect_elevenlabs/transfer')
         if not self.check_tool_token():
             raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
@@ -64,6 +73,7 @@ class ConnectElevenlabsController(http.Controller):
 
     @http.route('/connect_elevenlabs/post_call', methods=['POST'], type='http', auth='public', csrf=False)
     def post_call_webhook(self):
+        logger.info('Incoming request: /connect_elevenlabs/post_call')
         if not self.check_post_call_webhook():
             raise Unauthorized()
         user_connect_webhook = http.request.env.ref("connect.user_connect_webhook")

--- a/connect_elevenlabs/controllers/main.py
+++ b/connect_elevenlabs/controllers/main.py
@@ -16,7 +16,16 @@ logger = logging.getLogger(__name__)
 
 class ConnectElevenlabsController(http.Controller):
 
-    def check_agent_request(self):
+    def check_tool_token(self):
+        token = http.request.httprequest.headers.get('x-elevenlabs-agent-token')
+        if not token:
+            return False
+        expected_token = http.request.env['connect.settings'].sudo().get_param('elevenlabs_agent_token')
+        if not expected_token or token != expected_token:
+            return False
+        return True
+
+    def check_post_call_webhook(self):
         payload = http.request.httprequest.get_data(as_text=True)
         headers = http.request.httprequest.headers.get("elevenlabs-signature")
         if not headers:
@@ -44,8 +53,8 @@ class ConnectElevenlabsController(http.Controller):
 
     @http.route('/connect_elevenlabs/transfer', methods=['POST'], type='http', auth='public', csrf=False)
     def transfer_webhook(self):
-        # if not self.check_agent_request():
-        #     raise Unauthorized()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         agent = http.request.env['connect.elevenlabs_agent'].with_user(
             http.request.env.ref("connect.user_connect_webhook")).sudo()
@@ -55,31 +64,10 @@ class ConnectElevenlabsController(http.Controller):
 
     @http.route('/connect_elevenlabs/post_call', methods=['POST'], type='http', auth='public', csrf=False)
     def post_call_webhook(self):
+        if not self.check_post_call_webhook():
+            raise Unauthorized()
         user_connect_webhook = http.request.env.ref("connect.user_connect_webhook")
-        payload = http.request.httprequest.get_data(as_text=True)
-        data = json.loads(payload).get('data')
-        headers = http.request.httprequest.headers.get("elevenlabs-signature")
-        if not headers:
-            return False
-        timestamp = headers.split(",")[0][2:]
-        hmac_signature = headers.split(",")[1]
-        # Validate timestamp
-        tolerance = int(time.time()) - 30 * 60
-        if int(timestamp) < tolerance:
-            logger.info('Invalid elevenlabs post call webhook timestamp!')
-            return ''
-        # Validate signature
-        full_payload_to_sign = f"{timestamp}.{payload}"
-        webhook_secret = http.request.env['connect.settings'].sudo().get_param('elevenlabs_post_call_webhook_secret')
-        mac = hmac.new(
-            key=webhook_secret.encode("utf-8"),
-            msg=full_payload_to_sign.encode("utf-8"),
-            digestmod=sha256,
-        )
-        digest = 'v0=' + mac.hexdigest()
-        if hmac_signature != digest:
-            logger.info('Invalid elevenlabs post call webhook signature!')
-            return ''
+        data = json.loads(http.request.httprequest.get_data(as_text=True)).get('data')
 
         dynamic_variables = data.get('conversation_initiation_client_data').get('dynamic_variables')
         call_id = int(dynamic_variables.get('call_id'))

--- a/connect_elevenlabs/data/tools.xml
+++ b/connect_elevenlabs/data/tools.xml
@@ -4,36 +4,115 @@
         <!-- Elevenlabs Agent Tool: language_detection -->
         <record id="agent_tool_language_detection" model="connect.elevenlabs_agent_tool">
             <field name="name">language_detection</field>
-            <field name="description">Detect language of the caller.</field>
+            <field name="description">Change the conversation language when the user expresses a language preference explicitly.
+Call this function when:
+- Direct requests: "Can we speak in Spanish?", "Switch to French", "Let's continue in German"
+- Questions about capability: "Do you speak Portuguese?", "¿Hablas español?", "Parlez-vous français?"
+- Stated preferences: "I would prefer Italian", "Chinese would be better for me"
+
+Before calling this function, identify the target language with high confidence.
+
+Do not call this function when user mentions a language but doesn't request to speak it.
+
+Following languages are allowed to be selected: [languages will be populated at runtime]
+If target language is not in the list, let user know that you can't speak the target language.
+Further responses after tool call should be in the target language.</field>
             <field name="tool_type">system</field>
         </record>
 
         <!-- Elevenlabs Agent Tool: end_call -->
         <record id="agent_tool_end_call" model="connect.elevenlabs_agent_tool">
             <field name="name">end_call</field>
-            <field name="description">Elevenlabs built-in tool to end the call by user request.</field>
+            <field name="description">Gracefully conclude conversations when appropriate.
+Call this function when:
+1. EXPLICIT ENDINGS
+- User says goodbye variants: "bye," "see you," "that's all," etc.
+- User directly declines help: "no thanks," "I'm good," etc.
+- User indicates completion: "that's what I needed," "all set," etc.
+
+2. IMPLICIT ENDINGS
+- User gives minimal/disengaged responses after their needs are met
+- User expresses intention to leave: "I need to go," "getting late," etc.
+- Natural conversation conclusion after all queries are resolved
+
+Before calling this function:
+1. Confirm all user queries are fully addressed
+2. Provide a contextually appropriate closing response
+
+DO NOT:
+- Call this function during active problem-solving
+- End conversation when user expresses new concerns
+- Continue conversation after user has clearly indicated ending</field>
             <field name="tool_type">system</field>
+            <field name="disable_interruptions" eval="True"/>
         </record>
 
-        <!-- Elevenlabs Agent Tool:  skip_turn -->
+        <!-- Elevenlabs Agent Tool: skip_turn -->
         <record id="agent_tool_skip_turn" model="connect.elevenlabs_agent_tool">
             <field name="name">skip_turn</field>
-            <field name="description">Elevenlabs built-in tool</field>
+            <field name="description">Skip a turn when the user explicitly indicates they need a moment to think or perform an action.
+Do not respond verbally after calling this function; simply wait for the user to speak again.
+Use this function for utterances similar to:
+- "Give me a second"
+- "Let me think"
+- "Hold on, let me check"
+
+Do not call this function if the user is silent without expressing an intention to pause, or if they pose a direct question that requires a response.</field>
             <field name="tool_type">system</field>
         </record>
 
         <!-- Elevenlabs Agent Tool: play_keypad_touch_tone -->
         <record id="agent_tool_play_keypad_touch_tone" model="connect.elevenlabs_agent_tool">
             <field name="name">play_keypad_touch_tone</field>
-            <field name="description">Elevenlabs built-in tool</field>
+            <field name="description">Play DTMF (touch-tone) tones during a phone call to interact with automated systems.
+
+Use this function when:
+- The user needs to navigate phone menus (e.g., "Press 1 for sales, 2 for support")
+- Entering extensions or PIN codes
+- Interacting with automated phone systems
+- The user explicitly asks you to press certain numbers
+
+DTMF tones can include:
+- Digits: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+- Special tones: * (star), # (pound/hash)
+- Pauses: w (0.5 second pause), W (1 second pause)</field>
             <field name="tool_type">system</field>
         </record>
 
         <!-- Elevenlabs Agent Tool: voicemail_detection -->
         <record id="agent_tool_voicemail_detection" model="connect.elevenlabs_agent_tool">
             <field name="name">voicemail_detection</field>
-            <field name="description">Elevenlabs built-in tool</field>
+            <field name="description">Detect when a call has been answered by a voicemail system rather than a human.
+Call this function when you detect that the call recipient is not available and the call has been answered by an automated voicemail system.
+
+Common indicators of voicemail:
+- Automated greeting messages: "You have reached the voicemail of..."
+- Recording instructions: "Please leave a message after the beep/tone"
+- Voicemail system prompts: "Please leave your name and number"
+- Generic unavailable messages: "The number you have dialed is not available"
+
+Before calling this function:
+- Provide a specific reason referencing the actual voicemail content heard
+
+After calling this function:
+- If a voicemail message is configured, it will be played automatically
+- The call will end immediately after the message (or immediately if no message)
+
+You must provide a specific reason for detecting voicemail that references the exact wording that indicated voicemail.</field>
             <field name="tool_type">system</field>
+        </record>
+
+        <!-- Elevenlabs Agent Tool: transfer_to_agent -->
+        <record id="agent_tool_transfer_to_agent" model="connect.elevenlabs_agent_tool">
+            <field name="name">transfer_to_agent</field>
+            <field name="description">Transfer to another agent when the specified condition for the transfer is met.
+Do not ask for any confirmation from the user side.
+Never let the user know they are transferred to another agent.
+
+Here is the list of agents and their conditions for transfer:
+[transfer rules will be populated at runtime]</field>
+            <field name="tool_type">system</field>
+            <field name="disable_interruptions" eval="True"/>
         </record>
 
         <!-- Elevenlabs Agent Tool: transfer_to_exten -->

--- a/connect_elevenlabs/migrations/1.0.5/post-migrate.py
+++ b/connect_elevenlabs/migrations/1.0.5/post-migrate.py
@@ -1,0 +1,44 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Link transfer_to_agent tool to agents that already have transfer rules."""
+    cr.execute("""
+        SELECT id FROM ir_model_data
+        WHERE module = 'connect_elevenlabs'
+          AND name = 'agent_tool_transfer_to_agent'
+          AND model = 'connect.elevenlabs_agent_tool'
+    """)
+    row = cr.fetchone()
+    if not row:
+        logger.warning("agent_tool_transfer_to_agent XML-ID not found, skipping migration.")
+        return
+    tool_id = row[0]
+
+    # Get the actual resource id from ir_model_data
+    cr.execute("""
+        SELECT res_id FROM ir_model_data
+        WHERE id = %s
+    """, (tool_id,))
+    tool_res_id = cr.fetchone()[0]
+
+    # Find agents that have transfer rules but lack the tool in their M2M
+    cr.execute("""
+        INSERT INTO connect_elevenlabs_agent_connect_elevenlabs_agent_tool_rel
+            (connect_elevenlabs_agent_id, connect_elevenlabs_agent_tool_id)
+        SELECT DISTINCT t.agent, %(tool_id)s
+        FROM connect_elevenlabs_agent_transfer t
+        WHERE t.agent IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM connect_elevenlabs_agent_connect_elevenlabs_agent_tool_rel rel
+              WHERE rel.connect_elevenlabs_agent_id = t.agent
+                AND rel.connect_elevenlabs_agent_tool_id = %(tool_id)s
+          )
+    """, {"tool_id": tool_res_id})
+
+    count = cr.rowcount
+    if count:
+        logger.info("Linked transfer_to_agent tool to %d existing agent(s).", count)

--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -195,6 +195,13 @@ class ElevenlabsAgent(models.Model):
         for rec in self:
             rec.has_transfer_tool = transfer_tool in rec.tools if transfer_tool else False
 
+    @api.onchange("tools")
+    def _onchange_tools(self):
+        transfer_tool = self.env.ref(
+            "connect_elevenlabs.agent_tool_transfer_to_agent", raise_if_not_found=False
+        )
+        self.has_transfer_tool = transfer_tool in self.tools if transfer_tool else False
+
     @api.onchange("active_prompt_version")
     def _onchange_active_prompt_version(self):
         if self.active_prompt_version:

--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -185,7 +185,7 @@ class ElevenlabsAgent(models.Model):
     exten_number = fields.Char(related="exten.number")
     template = fields.Many2one("connect.elevenlabs_agent_template", ondelete="set null")
     transfer_to_agent = fields.One2many("connect.elevenlabs_agent_transfer", "agent")
-    has_transfer_tool = fields.Boolean(compute="_compute_has_transfer_tool")
+    has_transfer_tool = fields.Boolean(compute="_compute_has_transfer_tool", store=True)
 
     @api.depends("tools")
     def _compute_has_transfer_tool(self):

--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -8,7 +8,7 @@ import warnings
 import requests
 from elevenlabs.core.api_error import ApiError
 from elevenlabs.types import AgentPlatformSettingsRequestModel, ConversationalConfig
-from odoo import api, fields, models, release, tools
+from odoo import api, fields, models, release
 from odoo.addons.connect.models.settings import debug
 from odoo.addons.connect.models.twiml import pretty_xml
 from odoo.exceptions import ValidationError

--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -185,7 +185,7 @@ class ElevenlabsAgent(models.Model):
     exten_number = fields.Char(related="exten.number")
     template = fields.Many2one("connect.elevenlabs_agent_template", ondelete="set null")
     transfer_to_agent = fields.One2many("connect.elevenlabs_agent_transfer", "agent")
-    has_transfer_tool = fields.Boolean(compute="_compute_has_transfer_tool", store=True)
+    has_transfer_tool = fields.Boolean(compute="_compute_has_transfer_tool")
 
     @api.depends("tools")
     def _compute_has_transfer_tool(self):
@@ -194,13 +194,6 @@ class ElevenlabsAgent(models.Model):
         )
         for rec in self:
             rec.has_transfer_tool = transfer_tool in rec.tools if transfer_tool else False
-
-    @api.onchange("tools")
-    def _onchange_tools(self):
-        transfer_tool = self.env.ref(
-            "connect_elevenlabs.agent_tool_transfer_to_agent", raise_if_not_found=False
-        )
-        self.has_transfer_tool = transfer_tool in self.tools if transfer_tool else False
 
     @api.onchange("active_prompt_version")
     def _onchange_active_prompt_version(self):

--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -185,6 +185,15 @@ class ElevenlabsAgent(models.Model):
     exten_number = fields.Char(related="exten.number")
     template = fields.Many2one("connect.elevenlabs_agent_template", ondelete="set null")
     transfer_to_agent = fields.One2many("connect.elevenlabs_agent_transfer", "agent")
+    has_transfer_tool = fields.Boolean(compute="_compute_has_transfer_tool")
+
+    @api.depends("tools")
+    def _compute_has_transfer_tool(self):
+        transfer_tool = self.env.ref(
+            "connect_elevenlabs.agent_tool_transfer_to_agent", raise_if_not_found=False
+        )
+        for rec in self:
+            rec.has_transfer_tool = transfer_tool in rec.tools if transfer_tool else False
 
     @api.onchange("active_prompt_version")
     def _onchange_active_prompt_version(self):
@@ -483,41 +492,35 @@ class ElevenlabsAgent(models.Model):
     def _compute_built_in_tools(self):
         built_in_tools = {}
         for tool in self.tools:
-            if tool.tool_type == "system":
-                built_in_tools.update(
-                    {
-                        tool.name: {
-                            "type": "system",
-                            "name": tool.name,
-                            "description": "",
-                            "params": {"system_tool_type": tool.name},
-                            "disable_interruptions": False,
-                        },
-                    }
-                )
-        transfers = []
-        for transfer in self.transfer_to_agent:
-            transfers.append(
-                {
-                    "agent_id": transfer.transfer_to_agent.agent_uid,
-                    "condition": transfer.condition,
-                    "enable_transferred_agent_first_message": True,
-                }
-            )
-        built_in_tools.update(
-            {
-                "transfer_to_agent": {
-                    "type": "system",
-                    "name": "transfer_to_agent",
-                    "description": "",
-                    "params": {
-                        "system_tool_type": "transfer_to_agent",
-                        "transfers": transfers,
-                    },
-                    "disable_interruptions": True,
-                },
+            if tool.tool_type != "system":
+                continue
+
+            tool_config = {
+                "type": "system",
+                "name": tool.name,
+                "description": tool.description or "",
+                "params": {"system_tool_type": tool.name},
+                "disable_interruptions": tool.disable_interruptions,
+                "tool_error_handling_mode": "auto",
             }
-        )
+
+            if tool.name == "transfer_to_agent":
+                transfers = []
+                for transfer in self.transfer_to_agent:
+                    transfers.append(
+                        {
+                            "agent_id": transfer.transfer_to_agent.agent_uid,
+                            "condition": transfer.condition,
+                            "enable_transferred_agent_first_message": True,
+                        }
+                    )
+                tool_config["params"]["transfers"] = transfers
+            elif tool.name == "voicemail_detection":
+                tool_config["params"]["voicemail_message"] = tool.voicemail_message or ""
+            elif tool.name == "play_keypad_touch_tone":
+                tool_config["params"]["use_out_of_band_dtmf"] = tool.use_out_of_band_dtmf
+
+            built_in_tools[tool.name] = tool_config
 
         return built_in_tools
 

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -192,12 +192,23 @@ class ElevenlabsAgentTool(models.Model):
         result = super().write(vals)
         if not self.env.context.get('skip_elevenlabs') and not self.env.context.get('install_mode'):
             for record in self:
-                if record.synced and record.tool_id:
+                if record.tool_type == 'system':
+                    record._sync_system_tool_to_agents()
+                elif record.synced and record.tool_id:
                     try:
                         record.update_elevenlabs_tool()
                     except Exception as e:
                         logger.warning(f'Failed to update ElevenLabs tool {record.name}: {e}')
         return result
+
+    def _sync_system_tool_to_agents(self):
+        """Update all agents that use this system tool"""
+        agents = self.env['connect.elevenlabs_agent'].search([('tools', 'in', self.id)])
+        for agent in agents:
+            try:
+                agent.update_elevenlabs_agent()
+            except Exception as e:
+                logger.warning(f'Failed to update agent {agent.name} after system tool change: {e}')
 
     def unlink(self):
         """Override unlink to delete tool from ElevenLabs"""

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -7,6 +7,7 @@ import logging
 from odoo import models, fields, api, release
 from odoo.exceptions import ValidationError
 from elevenlabs import ToolRequestModel
+from elevenlabs.core.api_error import ApiError
 
 logger = logging.getLogger(__name__)
 if release.version_info[0] >= 19:
@@ -223,6 +224,14 @@ class ElevenlabsAgentTool(models.Model):
 
             logger.info(f'Successfully updated ElevenLabs tool: {self.name}')
 
+        except ApiError as e:
+            if e.status_code == 404:
+                logger.warning(f'Tool {self.name} not found in ElevenLabs, recreating...')
+                self.with_context(skip_elevenlabs=True).write({'tool_id': False, 'synced': False})
+                self._sync_to_elevenlabs()
+            else:
+                logger.error(f'Error updating ElevenLabs tool {self.name}: {e}')
+                raise ValidationError(f'Failed to update ElevenLabs tool: {str(e)}')
         except Exception as e:
             logger.error(f'Error updating ElevenLabs tool {self.name}: {e}')
             raise ValidationError(f'Failed to update ElevenLabs tool: {str(e)}')

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -105,6 +105,7 @@ class ElevenlabsAgentTool(models.Model):
                 tool_config = {
                     'name': self.name,
                     'description': self.description,
+                    'type': self.tool_type,
                     'expects_response': self.client_expects_response,
                     'parameters': {
                         'type': 'object',
@@ -160,6 +161,7 @@ class ElevenlabsAgentTool(models.Model):
                 tool_config = {
                     'name': self.name,
                     'description': self.description,
+                    'type': self.tool_type,
                     'api_schema': api_schema,
                     'response_timeout_secs': self.response_timeout_secs,
                     'dynamic_variables': dynamic_variable_placeholders,

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -40,6 +40,12 @@ class ElevenlabsAgentTool(models.Model):
     ], default='body', required=True)
     client_expects_response = fields.Boolean(string='Expects Response',
                                              help='If true, calling this tool should block the conversation until the client responds with some response which is passed to the llm. If false then we will continue the conversation without waiting for the client to respond, this is useful to show content to a user but not block the conversation')
+    disable_interruptions = fields.Boolean(default=False,
+                                           help='If true, user cannot interrupt the agent while this tool is being executed')
+    voicemail_message = fields.Text(string='Voicemail Message',
+                                    help='Message to play when voicemail is detected. Leave empty for no message.')
+    use_out_of_band_dtmf = fields.Boolean(string='Out of Band DTMF', default=False,
+                                          help='Use out-of-band DTMF tones instead of in-band audio tones')
 
     # Use modern constraint syntax for Odoo 19, fallback to legacy for older versions
     if release.version_info[0] >= 19:

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -116,9 +116,15 @@ class ElevenlabsAgentTool(models.Model):
 
             elif self.tool_type == 'webhook':
                 # Build webhook tool configuration
+                agent_token = self.env['connect.settings'].sudo().get_param('elevenlabs_agent_token')
                 api_schema = {
                     'method': self.method,
                     'url': self.get_tool_url(),
+                    'request_headers': [{
+                        'type': 'value',
+                        'name': 'x-elevenlabs-agent-token',
+                        'value': agent_token,
+                    }],
                 }
 
                 # Add request body schema for body parameters

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -122,11 +122,9 @@ class ElevenlabsAgentTool(models.Model):
                 api_schema = {
                     'method': self.method,
                     'url': self.get_tool_url(),
-                    'request_headers': [{
-                        'type': 'value',
-                        'name': 'x-elevenlabs-agent-token',
-                        'value': agent_token,
-                    }],
+                    'request_headers': {
+                        'x-elevenlabs-agent-token': agent_token,
+                    },
                 }
 
                 # Add request body schema for body parameters

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -86,7 +86,7 @@ class ElevenlabsAgentTool(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        if not self.env.context.get('install_mode'):
+        if res.tool_type != 'system' and not self.env.context.get('install_mode'):
             res._sync_to_elevenlabs()
         return res
 
@@ -192,12 +192,23 @@ class ElevenlabsAgentTool(models.Model):
         result = super().write(vals)
         if not self.env.context.get('skip_elevenlabs') and not self.env.context.get('install_mode'):
             for record in self:
-                if record.synced and record.tool_id:
+                if record.tool_type == 'system':
+                    record._sync_system_tool_to_agents()
+                elif record.synced and record.tool_id:
                     try:
                         record.update_elevenlabs_tool()
                     except Exception as e:
                         logger.warning(f'Failed to update ElevenLabs tool {record.name}: {e}')
         return result
+
+    def _sync_system_tool_to_agents(self):
+        """System tools are part of agent config, sync by updating all agents that use this tool"""
+        agents = self.env['connect.elevenlabs_agent'].search([('tools', 'in', self.id)])
+        for agent in agents:
+            try:
+                agent.update_elevenlabs_agent()
+            except Exception as e:
+                logger.warning(f'Failed to update agent {agent.name} after system tool change: {e}')
 
     def unlink(self):
         """Override unlink to delete tool from ElevenLabs"""

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -17,7 +17,7 @@ if release.version_info[0] >= 19:
 class ElevenlabsAgentTool(models.Model):
     _name = 'connect.elevenlabs_agent_tool'
     _description = 'Elevenlabs Agent Tool'
-    _order = 'tool_type ASC, name ASC'
+    _order = 'name ASC'
 
     name = fields.Char(required=True)
     tool_id = fields.Char()

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -86,7 +86,7 @@ class ElevenlabsAgentTool(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        if res.tool_type != 'system' and not self.env.context.get('install_mode'):
+        if not self.env.context.get('install_mode'):
             res._sync_to_elevenlabs()
         return res
 
@@ -192,23 +192,12 @@ class ElevenlabsAgentTool(models.Model):
         result = super().write(vals)
         if not self.env.context.get('skip_elevenlabs') and not self.env.context.get('install_mode'):
             for record in self:
-                if record.tool_type == 'system':
-                    record._sync_system_tool_to_agents()
-                elif record.synced and record.tool_id:
+                if record.synced and record.tool_id:
                     try:
                         record.update_elevenlabs_tool()
                     except Exception as e:
                         logger.warning(f'Failed to update ElevenLabs tool {record.name}: {e}')
         return result
-
-    def _sync_system_tool_to_agents(self):
-        """Update all agents that use this system tool"""
-        agents = self.env['connect.elevenlabs_agent'].search([('tools', 'in', self.id)])
-        for agent in agents:
-            try:
-                agent.update_elevenlabs_agent()
-            except Exception as e:
-                logger.warning(f'Failed to update agent {agent.name} after system tool change: {e}')
 
     def unlink(self):
         """Override unlink to delete tool from ElevenLabs"""

--- a/connect_elevenlabs/models/agent_tool.py
+++ b/connect_elevenlabs/models/agent_tool.py
@@ -182,10 +182,9 @@ class ElevenlabsAgentTool(models.Model):
             raise ValidationError(f'Failed to create tool configuration: {str(e)}')
 
     def write(self, vals):
-        print(vals)
         """Override write to update tool in ElevenLabs when changed"""
         result = super().write(vals)
-        if not self.env.context.get('skip_elevenlabs') or not self.env.context.get('install_mode'):
+        if not self.env.context.get('skip_elevenlabs') and not self.env.context.get('install_mode'):
             for record in self:
                 if record.synced and record.tool_id:
                     try:
@@ -306,7 +305,7 @@ class ElevenlabsAgentToolparams(models.Model):
     _name = 'connect.agent_tool_params'
     _description = 'Elevenlabs Agent Tool Parameters'
 
-    name = fields.Char(name='Identifier')
+    name = fields.Char(string='Identifier')
     data_type = fields.Selection(
         [('string', 'String'), ('boolean', 'Boolean'), ('integer', 'Integer')], default='string', required=True)
     required = fields.Boolean()

--- a/connect_elevenlabs/models/call.py
+++ b/connect_elevenlabs/models/call.py
@@ -17,10 +17,9 @@ class Call(models.Model):
     def _get_recording_data(self):
         super(Call, self)._get_recording_data()
         for rec in self:
-            # Also show recording icons on Agent calls.
-            if rec.elevenlabs_agent:
+            # Also show recording icons on Agent calls when recording exists.
+            if rec.elevenlabs_agent and rec.recording:
                 rec.recording_icon = '<span class="fa fa-file-sound-o"/>'
-                # No need for else condition as it's already set in super().
 
     def elevenlabs_agent_get_call_data(self):
         self.ensure_one()

--- a/connect_elevenlabs/models/settings.py
+++ b/connect_elevenlabs/models/settings.py
@@ -94,10 +94,8 @@ class Elevenlabsettings(models.Model):
         self.elevenlabs_get_voices()
         self.connect_notify('Voices sync done!', title='Elevenlabs Agent', notify_uid=self.env.user.id)
         self.elevenlabs_reset_token()
-        # Sync tools first
-        for tool in self.env['connect.elevenlabs_agent_tool'].search([('tool_id', '=', False)]):
-            tool._sync_to_elevenlabs()
-        self.connect_notify('Tools sync done!', title='Elevenlabs Agent', notify_uid=self.env.user.id)
+        # Sync tools (create new + update existing with new token)
+        self.elevenlabs_sync_tools()
 
         for agent in self.env['connect.elevenlabs_agent'].search([]):
             agent.update_elevenlabs_agent()

--- a/connect_elevenlabs/models/settings.py
+++ b/connect_elevenlabs/models/settings.py
@@ -80,8 +80,9 @@ class Elevenlabsettings(models.Model):
 
 
     def elevenlabs_sync_tools(self):
-        """Sync all tools to ElevenLabs (create or update)"""
-        tools = self.env['connect.elevenlabs_agent_tool'].search([])
+        """Sync all tools to ElevenLabs (create or update).
+        System tools are excluded — they are managed via agent config (PATCH agent)."""
+        tools = self.env['connect.elevenlabs_agent_tool'].search([('tool_type', '!=', 'system')])
         for tool in tools:
             if tool.tool_id:
                 tool.update_elevenlabs_tool()

--- a/connect_elevenlabs/models/settings.py
+++ b/connect_elevenlabs/models/settings.py
@@ -80,13 +80,16 @@ class Elevenlabsettings(models.Model):
 
 
     def elevenlabs_sync_tools(self):
-        """Sync all non-system tools to ElevenLabs (create or update)"""
+        """Sync all tools to ElevenLabs (create or update)"""
         tools = self.env['connect.elevenlabs_agent_tool'].search([('tool_type', '!=', 'system')])
         for tool in tools:
             if tool.tool_id:
                 tool.update_elevenlabs_tool()
             else:
                 tool._sync_to_elevenlabs()
+        # System tools are part of agent config, update all agents to sync them
+        for agent in self.env['connect.elevenlabs_agent'].search([]):
+            agent.update_elevenlabs_agent()
         self.connect_notify('Tools sync done!', title='Elevenlabs Agent', notify_uid=self.env.user.id)
 
     def elevenlabs_sync(self):

--- a/connect_elevenlabs/models/settings.py
+++ b/connect_elevenlabs/models/settings.py
@@ -81,15 +81,12 @@ class Elevenlabsettings(models.Model):
 
     def elevenlabs_sync_tools(self):
         """Sync all tools to ElevenLabs (create or update)"""
-        tools = self.env['connect.elevenlabs_agent_tool'].search([('tool_type', '!=', 'system')])
+        tools = self.env['connect.elevenlabs_agent_tool'].search([])
         for tool in tools:
             if tool.tool_id:
                 tool.update_elevenlabs_tool()
             else:
                 tool._sync_to_elevenlabs()
-        # System tools are part of agent config, update all agents to sync them
-        for agent in self.env['connect.elevenlabs_agent'].search([]):
-            agent.update_elevenlabs_agent()
         self.connect_notify('Tools sync done!', title='Elevenlabs Agent', notify_uid=self.env.user.id)
 
     def elevenlabs_sync(self):
@@ -97,8 +94,7 @@ class Elevenlabsettings(models.Model):
         self.connect_notify('Voices sync done!', title='Elevenlabs Agent', notify_uid=self.env.user.id)
         self.elevenlabs_reset_token()
         # Sync tools first
-        for tool in self.env['connect.elevenlabs_agent_tool'].search([
-            ('tool_type', '!=', 'system'), ('tool_id', '=', False)]):
+        for tool in self.env['connect.elevenlabs_agent_tool'].search([('tool_id', '=', False)]):
             tool._sync_to_elevenlabs()
         self.connect_notify('Tools sync done!', title='Elevenlabs Agent', notify_uid=self.env.user.id)
 

--- a/connect_elevenlabs/views/agent.xml
+++ b/connect_elevenlabs/views/agent.xml
@@ -61,7 +61,8 @@
                                     <field name="name"/>
                                     <field name="voice"/>
                                     <field name="tools" widget="many2many_tags"/>
-                                    <field name="transfer_to_agent">
+                                    <field name="has_transfer_tool" invisible="1"/>
+                                    <field name="transfer_to_agent" invisible="not has_transfer_tool">
                                         <list>
                                             <field name="transfer_to_agent" string="Agent"/>
                                             <field name="condition"/>

--- a/connect_elevenlabs/views/agent_tool.xml
+++ b/connect_elevenlabs/views/agent_tool.xml
@@ -37,7 +37,7 @@
                         <field name="description"/>
                         <field name="tool_type" readonly="tool_type == 'system'"/>
                         <field name="tool_id" readonly="1" invisible="tool_type == 'system'" groups="base.group_no_one"/>
-                        <field name="synced" readonly="1"/>
+                        <field name="synced" readonly="1" invisible="tool_type == 'system'"/>
                         <field name="param_type" string="Parameters Type"
                                invisible="tool_type != 'webhook'"/>
                         </group>

--- a/connect_elevenlabs/views/agent_tool.xml
+++ b/connect_elevenlabs/views/agent_tool.xml
@@ -36,6 +36,7 @@
                         <field name="name" readonly="tool_type == 'system'"/>
                         <field name="description"/>
                         <field name="tool_type" readonly="tool_type == 'system'"/>
+                        <field name="tool_id" readonly="1" invisible="tool_type == 'system'" groups="base.group_no_one"/>
                         <field name="synced" readonly="1"/>
                         <field name="param_type" string="Parameters Type"
                                invisible="tool_type != 'webhook'"/>

--- a/connect_elevenlabs/views/agent_tool.xml
+++ b/connect_elevenlabs/views/agent_tool.xml
@@ -52,6 +52,12 @@
                                    invisible="tool_type != 'client'"/>
                             <field name="response_timeout_secs"
                                    invisible="tool_type == 'system'"/>
+                            <field name="disable_interruptions"
+                                   invisible="tool_type != 'system'"/>
+                            <field name="voicemail_message"
+                                   invisible="name != 'voicemail_detection'"/>
+                            <field name="use_out_of_band_dtmf"
+                                   invisible="name != 'play_keypad_touch_tone'"/>
                         </group>
                     </group>
                     <group string="Parameters" invisible="tool_type == 'system'">

--- a/connect_elevenlabs_helpdesk/controllers/main.py
+++ b/connect_elevenlabs_helpdesk/controllers/main.py
@@ -2,6 +2,9 @@
 
 import json
 import logging
+
+from werkzeug.exceptions import Unauthorized
+
 from odoo import http, release
 from odoo.addons.connect_elevenlabs.controllers.main import ConnectElevenlabsController
 
@@ -14,7 +17,8 @@ class ConnectElevenlabsHelpdeskController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_helpdesk/create_ticket', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def helpdesk_create_ticket(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent create_ticket data: %s', data)
         call_id = int(data.get('call_id'))
@@ -53,7 +57,8 @@ class ConnectElevenlabsHelpdeskController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_helpdesk/search_tickets', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def helpdesk_search_tickets(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent search_tickets data: %s', data)
         partner_id = data.get('partner_id')
@@ -81,7 +86,8 @@ class ConnectElevenlabsHelpdeskController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_helpdesk/fetch_ticket', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def helpdesk_fetch_ticket(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent fetch_ticket data: %s', data)
         ticket_id = data.get('ticket_id')
@@ -109,7 +115,8 @@ class ConnectElevenlabsHelpdeskController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_helpdesk/update_ticket', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def helpdesk_update_ticket(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent update_ticket data: %s', data)
         ticket_id = data.get('ticket_id')
@@ -139,7 +146,8 @@ class ConnectElevenlabsHelpdeskController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_helpdesk/ticket_activity', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def helpdesk_ticket_activity(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent ticket_activity data: %s', data)
         ticket_id = data.get('ticket_id')

--- a/connect_elevenlabs_sale/controllers/main.py
+++ b/connect_elevenlabs_sale/controllers/main.py
@@ -2,6 +2,9 @@
 
 import json
 import logging
+
+from werkzeug.exceptions import Unauthorized
+
 from odoo import http, release
 from odoo.addons.connect_elevenlabs.controllers.main import ConnectElevenlabsController
 
@@ -13,7 +16,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/create_partner', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def create_partner(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         call = http.request.env['connect.call'].sudo().browse(int(data['call_id']))
@@ -38,7 +42,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/get_products', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def get_products(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         products = http.request.env['product.template'].sudo().search([])
@@ -57,7 +62,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/create_order', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def create_order(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         # Create the sale order
@@ -89,7 +95,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/get_order', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def get_order(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         call = http.request.env['connect.call'].sudo().browse(int(data['call_id']))
@@ -131,8 +138,9 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/get_orders', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def get_orders(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
-        self.check_agent_request()
         logger.info('Agent data: %s', data)
         call = http.request.env['connect.call'].sudo().browse(int(data['call_id']))
         if call.direction == 'outgoing':


### PR DESCRIPTION
- Replace broken check_agent_request with check_tool_token + Unauthorized
- Handle named timezone strings in calendar controller
- Show recording icon only when recording exists for agent calls
- Use elevenlabs_sync_tools() method instead of inline loop
- Add post-migrate 1.0.5 to link transfer_to_agent tool to agents with existing transfer rules
- Remove unused imports, set default sort order for agent tools
- Version bump to 1.0.5