### PR TITLE
feat: make CallFlow ring timeout configurable

### DIFF
--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -46,6 +46,8 @@ class CallFlow(models.Model):
     choices = fields.One2many('connect.callflow_choice', 'callflow')
     gather_action_url = fields.Char(compute='_get_gather_action_url')
     ring_users = fields.Many2many('connect.user')
+    ring_timeout = fields.Integer(string='Ring Timeout', default=30,
+        help='Number of seconds to ring users before timeout. Default is 30 seconds.')
     record_calls = fields.Boolean()
     voicemail_prompt = fields.Text()
     voicemail_enabled = fields.Boolean()
@@ -114,10 +116,10 @@ class CallFlow(models.Model):
                     response.say('Your must configure a default number for caller ID!')
                     return response
             if self.record_calls:
-                dial = Dial(callerId=callerId, action=action_url,
+                dial = Dial(callerId=callerId, action=action_url, timeout=self.ring_timeout,
                         record='record-from-answer-dual', recordingStatusCallback=record_status_url)
             else:
-                dial = Dial(callerId=callerId, action=action_url)
+                dial = Dial(callerId=callerId, action=action_url, timeout=self.ring_timeout)
             for user in self.ring_users:
                 callflows = self.env['connect.user_callflow'].sudo().search(
                     [('callflow_type', 'in', ['sip', 'client']), ('user', '=', user.id)], order='prio')

--- a/connect/views/callflow.xml
+++ b/connect/views/callflow.xml
@@ -63,6 +63,7 @@
                             </div>
                             <field name="voice" placeholder="man"/>
                             <field name="ring_users" widget="many2many_tags"/>
+                            <field name="ring_timeout"/>
                             <field name="record_calls"/>
                             <field name="voicemail_enabled"/>
                             <field name="voicemail_prompt"


### PR DESCRIPTION
## Summary
- Add configurable `ring_timeout` field to CallFlow model (default 30s for backward compatibility)
- Pass timeout to Twilio `Dial()` instead of relying on hardcoded 30s default
- Add field to CallFlow form view

🤖 Generated with [Claude Code](https://claude.com/claude-code)