### PR TITLE
Connect EE features: contact manager, transcription rules, AI chatter, fallback destinations

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -13,7 +13,7 @@
     'category': 'Phone',
     'summary': 'Twilio and Odoo integration application',
     'description': '',
-    'depends': ['mail', 'contacts', 'sms'],
+    'depends': ['mail', 'contacts', 'sms', 'resource'],
     'external_dependencies': {
         'python': ['twilio', 'openai'],
     },
@@ -75,6 +75,7 @@
             '/connect/static/src/services/actions/*',
             '/connect/static/src/services/active_calls/*',
             '/connect/static/src/services/mail/*',
+            '/connect/static/src/core/common/*',
         ],
     },
 }

--- a/connect/controllers/main.py
+++ b/connect/controllers/main.py
@@ -2,12 +2,14 @@
 
 import json
 import logging
+import os
 from datetime import timedelta
 
+import openai
 import requests
 from werkzeug.exceptions import NotFound
 
-from odoo import fields, http, release
+from odoo import fields, http, release, tools
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import UserError
 
@@ -310,6 +312,47 @@ class ConnectController(http.Controller):
             call.transfer_context = current_context
         except Exception as e:
             logger.error(f'Failed to store external termination context: {e}')
+
+    @http.route("/connect/ai_completion", type="json", auth="user")
+    def ai_completion(self, model, res_id):
+        openai_api_key = http.request.env["connect.settings"].sudo().get_param("openai_api_key")
+        if not openai_api_key:
+            return {"status": "fail", "error_message": "Missing OpenAI API key!"}
+        records = (
+            http.request.env["mail.message"]
+            .sudo()
+            .search([("res_id", "=", res_id), ("model", "=", model)], order="id desc")
+        )
+        data = []
+        for rec in records:
+            if rec.message_type == "notification":
+                continue
+            data.append(f"{rec.author_id.name or 'Anonymous'}: {tools.html2plaintext(rec.body)}")
+        segments = "\n".join(data)
+
+        client = openai.OpenAI(api_key=openai_api_key)
+
+        default_prompt = "Continue the conversation naturally!"
+        prompt = http.request.env["connect.settings"].sudo().get_param("chatter_message_generate_prompt")
+
+        response = client.chat.completions.create(
+            model=os.environ.get("OPENAI_COMPLETION_MODEL", "gpt-4o"),
+            messages=[
+                {"role": "user", "content": f"{prompt or default_prompt} \nOmit dialog name from final message!"},
+                {
+                    "role": "user",
+                    "content": segments,
+                },
+            ],
+            temperature=float(os.environ.get("OPENAI_COMPLETION_TEMPERATURE", 0.5)),
+            max_tokens=int(os.environ.get("OPENAI_COMPLETION_MAX_TOKENS", 4096)),
+            top_p=float(os.environ.get("OPENAI_COMPLETION_TOP_P", 1.0)),
+            frequency_penalty=float(os.environ.get("OPENAI_COMPLETION_FREQUENCY_PENALTY", 0.0)),
+            presence_penalty=float(os.environ.get("OPENAI_COMPLETION_PRESENSE_PENALTY", 0.0)),
+        )
+        logger.info("%s", response.usage)
+        message = response.choices[0].message.content.strip("\n\n")
+        return {"status": "ok", "message": message}
 
     @http.route('/connect/health/<string:uid>/', methods=['GET', 'POST'], type='http', auth='public', csrf=False)
     def health_check(self, uid):

--- a/connect/controllers/twilio_webhooks.py
+++ b/connect/controllers/twilio_webhooks.py
@@ -131,6 +131,14 @@ class ConnectController(Controller):
         request.env['connect.whatsapp_sender'].with_user(request.env.ref("connect.user_connect_webhook")).update_message_status(kw)
         return 'OK'
 
+    @route('/twilio/webhook/connect_callflow_ring_contact_manager_action/<int:record_id>', methods=['POST'], type='http', auth='public', csrf=False)
+    def callflow_ring_contact_manager_action(self, record_id, **kw):
+        if not self.check_signature(kw):
+            return '<Response><Say>Invalid Twilio request!</Say></Response>'
+        model = request.env['connect.callflow'].with_user(request.env.ref("connect.user_connect_webhook"))
+        res = model.on_ring_contact_manager_action(record_id, kw)
+        return f'{res}'
+
     @route('/twilio/webhook/transfer_continuation', methods=['POST'], type='http', auth='public', csrf=False)
     def transfer_continuation_webhook(self, **kw):
         if not self.check_signature(kw):

--- a/connect/i18n/de.po
+++ b/connect/i18n/de.po
@@ -1,0 +1,78 @@
+# Translation of Odoo Server.
+# This file contains the translation of the connect module for German language.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-02-24 19:20+0000\n"
+"PO-Revision-Date: 2026-02-24 19:20+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: de\n"
+
+#. module: connect
+#: model:ir.module.category,name:connect.module_category_connect
+#: model:ir.ui.menu,name:connect.menu_connect
+#: model_terms:ir.ui.view,arch_db:connect.connect_settings_form
+msgid "Connect"
+msgstr "Verbindung"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_call__name
+msgid "Call"
+msgstr "Anruf"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_callflow__name
+msgid "Call Flow"
+msgstr "Anruffluss"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_channel__name
+msgid "Channel"
+msgstr "Kanal"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_domain__name
+msgid "Domain"
+msgstr "Domäne"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_exten__name
+msgid "Extension"
+msgstr "Erweiterung"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_exten__uuid
+msgid "UUID"
+msgstr "UUID"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_exten__description
+msgid "Description"
+msgstr "Beschreibung"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_settings__company_id
+msgid "Company"
+msgstr "Unternehmen"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_settings__name
+msgid "Name"
+msgstr "Name"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_settings__phone_number
+msgid "Phone Number"
+msgstr "Telefonnummer"
+
+#. module: connect
+#: model:ir.model.fields,field_description:connect.field_connect_settings__sip_domain
+msgid "SIP Domain"
+msgstr "SIP-Domäne"

--- a/connect/models/__init__.py
+++ b/connect/models/__init__.py
@@ -11,6 +11,7 @@ from . import message_configuration
 from . import number
 from . import outgoing_callerid
 from . import recording
+from . import recording_transcription_rules
 from . import res_partner
 from . import res_users
 from . import settings

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -2,11 +2,17 @@
 
 import json
 import logging
+import os
 import re
+from tempfile import NamedTemporaryFile
 from urllib.parse import urljoin
 from markupsafe import Markup
 import uuid
 from datetime import timedelta
+
+import openai
+import requests
+
 from odoo import fields, models, api, release, SUPERUSER_ID, tools
 from odoo.exceptions import ValidationError
 from twilio.twiml.voice_response import VoiceResponse, Say, Dial, Conference, Client, Number, Sip
@@ -80,6 +86,8 @@ class Call(models.Model):
         voicemail_widget = fields.Html(compute='_get_voicemail_widget', string='VoiceMail', sanitize=False)
     else:
         voicemail_widget = fields.Char(compute='_get_voicemail_widget', string='VoiceMail')
+    voicemail_transcript = fields.Text()
+    voicemail_transcription_error = fields.Char()
     # Reference, to submit call history and summary.
     ref = fields.Reference(selection=[('res.partner', 'Partner')], compute='_get_ref')
     has_error = fields.Boolean(index=True)
@@ -173,6 +181,44 @@ class Call(models.Model):
                 rec.voicemail_icon = '<span class="fa fa-envelope-o"/>'
             else:
                 rec.voicemail_icon = ''
+
+    @api.constrains('voicemail_url')
+    def _transcribe_voicemail(self):
+        self.ensure_one()
+        openai_key = self.env['connect.settings'].sudo().get_param('openai_api_key')
+        if not openai_key:
+            logger.warning('OpenAI key is not set! Transcription will not be available.')
+            return False
+        if self.voicemail_url:
+            self.transcribe_voicemail(openai_key)
+        else:
+            logger.warning('Voicemail is not available yet!')
+
+    def transcribe_voicemail(self, openai_api_key):
+        result = {}
+        try:
+            client = openai.OpenAI(api_key=openai_api_key)
+            response = requests.get(self.voicemail_url, stream=True)
+            response.raise_for_status()
+            with NamedTemporaryFile(delete=False, suffix=".mp3") as temp_file:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        temp_file.write(chunk)
+                temp_file_path = temp_file.name
+            with open(temp_file_path, 'rb') as audio_file:
+                transcript = client.audio.transcriptions.create(
+                    model="whisper-1", file=audio_file,
+                    response_format='verbose_json', timestamp_granularities=["segment"])
+            segments = ''
+            for s in transcript.segments:
+                segments += '{}\n'.format(s.text)
+            result['voicemail_transcript'] = segments.strip()
+            result['voicemail_transcription_error'] = False
+        except Exception as e:
+            logger.exception('Voicemail transcribe error:')
+            result['voicemail_transcription_error'] = str(e)
+        finally:
+            self.write(result)
 
     @api.depends('duration')
     def _get_duration_human(self):

--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from datetime import datetime
 from urllib.parse import urljoin
+from pytz import utc
 from odoo import fields, models, api, release
 from twilio.twiml.voice_response import Gather, VoiceResponse, Say, Client, Sip, Dial
 from .twiml import pretty_xml
@@ -47,6 +49,13 @@ class CallFlow(models.Model):
     gather_action_url = fields.Char(compute='_get_gather_action_url')
     ring_users = fields.Many2many('connect.user')
     record_calls = fields.Boolean()
+    ring_contact_manager = fields.Boolean(string='Connect to Manager', default=False)
+    ring_contact_manager_timeout = fields.Integer(string='Connect Timeout', default=15, required=True)
+    ring_contact_manager_prompt = fields.Text(string='Connect Manager Prompt',
+        default='Please wait while I connect you to your account manager...',
+        help='If not set the caller will hear a standard ringing tone.')
+    calendar = fields.Many2one('resource.calendar', string='Calendar')
+    off_calendar_callflow = fields.Many2one('connect.callflow', string='Off Calendar Callflow')
     voicemail_prompt = fields.Text()
     voicemail_enabled = fields.Boolean()
     # fallback_extension
@@ -75,8 +84,29 @@ class CallFlow(models.Model):
             return callflow.render(request=request, params={'invalid_input': True})
         return choice[0].exten.render(request=request)
 
-    def render(self, request={}, params={}):
+    def render(self, request={}, params={}, fallback_effort=0):
         self.ensure_one()
+        # If a calendar is set for this call flow, check if the current time is within business hours.
+        if self.calendar:
+            now_utc = datetime.now(utc)
+            end_time = now_utc.replace(hour=23, minute=59, second=59)
+            intervals = self.calendar.sudo()._work_intervals_batch(now_utc, end_time)[False]
+            is_working_time = any(start <= now_utc < end for start, end, meta in intervals)
+            if not is_working_time:
+                if self.off_calendar_callflow:
+                    debug(self, 'Outside of calendar hours, rendering off-calendar callflow.')
+                    return self.off_calendar_callflow.render(request, params, fallback_effort+1)
+                else:
+                    debug(self, 'Outside of calendar hours, no off-calendar callflow, hanging up.')
+                    response = VoiceResponse()
+                    response.say('Outside of calendar hours! Goodbye!')
+                    response.hangup()
+                    return response
+
+        if self.ring_contact_manager and not params.get('no_ring_contact_manager'):
+            response = self.render_ring_contact_manager(request, params=params)
+            return response
+
         api_url = self.env['connect.settings'].sudo().get_param('api_url')
         edge = self.env['connect.settings'].sudo().get_param('twilio_edge')
         voicemail_record_status_url = urljoin(api_url,
@@ -161,6 +191,38 @@ class CallFlow(models.Model):
 
     def get_voicemail_prompt_message(self, response):
         response.say(self.voicemail_prompt, language=self.language, voice=self.voice)
+
+    def render_ring_contact_manager(self, request, params={}):
+        self.ensure_one()
+        api_url = self.env['connect.settings'].sudo().get_param('api_url')
+        action_url = urljoin(api_url, 'twilio/webhook/connect_callflow_ring_contact_manager_action/{}'.format(self.id))
+        response = VoiceResponse()
+        # Check the partner by number
+        partner = self.env['res.partner'].get_partner_by_number(request['Caller'])
+        if not (partner and partner.user_id):
+            debug(self, 'Contact Manager for number {} not found.'.format(request['Caller']))
+            return super(CallFlow, self).render(request, params)
+        else:
+            debug(self, 'Found partner {}[{}] for number {}.'.format(partner.name, partner.id, request['Caller']))
+        # Check partner's PBX user.
+        connect_user = partner.user_id.connect_user
+        if not connect_user:
+            debug(self, 'Connect User for Sale Manager {}[{}] is not configured.'.format(
+                partner.user_id.name, partner.user_id.id))
+            return super(CallFlow, self).render(request, params)
+        # Render connect user
+        debug(self, 'Connect caller to Manager {}[{}].'.format(partner.user_id.name, partner.user_id.id))
+        return connect_user.render(request, params={'dial_action_url': action_url})
+
+    def on_ring_contact_manager_action(self, flow_id, request):
+        if request['DialCallStatus'] != 'completed':
+            debug(self, 'Contact Manager dial status: {}, fallback on the callflow.'.format(request['DialCallStatus']))
+            return self.browse(flow_id).render(request, params={'no_ring_contact_manager': True})
+        else:
+            debug(self, 'Contact Manager successfully answered the call. Hangup.')
+            response = VoiceResponse()
+            response.hangup()
+            return response
 
     @api.model
     def on_call_action(self, flow_id, request):

--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -201,7 +201,7 @@ class CallFlow(models.Model):
         partner = self.env['res.partner'].get_partner_by_number(request['Caller'])
         if not (partner and partner.user_id):
             debug(self, 'Contact Manager for number {} not found.'.format(request['Caller']))
-            return super(CallFlow, self).render(request, params)
+            return self.render(request, params)
         else:
             debug(self, 'Found partner {}[{}] for number {}.'.format(partner.name, partner.id, request['Caller']))
         # Check partner's PBX user.
@@ -209,7 +209,7 @@ class CallFlow(models.Model):
         if not connect_user:
             debug(self, 'Connect User for Sale Manager {}[{}] is not configured.'.format(
                 partner.user_id.name, partner.user_id.id))
-            return super(CallFlow, self).render(request, params)
+            return self.render(request, params)
         # Render connect user
         debug(self, 'Connect caller to Manager {}[{}].'.format(partner.user_id.name, partner.user_id.id))
         return connect_user.render(request, params={'dial_action_url': action_url})

--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -199,6 +199,7 @@ class CallFlow(models.Model):
         response = VoiceResponse()
         # Check the partner by number
         partner = self.env['res.partner'].get_partner_by_number(request['Caller'])
+        params.update({'no_ring_contact_manager': True})
         if not (partner and partner.user_id):
             debug(self, 'Contact Manager for number {} not found.'.format(request['Caller']))
             return self.render(request, params)

--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -1,7 +1,12 @@
 import ast
 import logging
+import os
+from tempfile import NamedTemporaryFile
 from urllib.parse import urljoin
+
+import openai
 import phonenumbers
+import requests
 from markupsafe import Markup
 from phonenumbers import parse, format_number, PhoneNumberFormat
 from twilio.twiml.messaging_response import MessagingResponse
@@ -57,6 +62,7 @@ class ConnectMessage(models.Model):
     parent_message = fields.Many2one('connect.message', string='In Reply To', readonly=True)
     media_url = fields.Char()
     media_content_type = fields.Char()
+    transcription_error = fields.Char()
     if release.version_info[0] >= 17.0:
         media_widget = fields.Html(compute='_get_media_widget', string='Media', sanitize=False)
     else:
@@ -171,8 +177,33 @@ class ConnectMessage(models.Model):
             else:
                 record.name = f"New {record.message_type}"
 
+    def transcribe_voice_message(self, openai_api_key, media_url):
+        result = {}
+        try:
+            client = openai.OpenAI(api_key=openai_api_key)
+            response = requests.get(media_url, stream=True)
+            response.raise_for_status()
+            with NamedTemporaryFile(delete=False, suffix=".mp3") as temp_file:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        temp_file.write(chunk)
+                temp_file_path = temp_file.name
+            with open(temp_file_path, 'rb') as audio_file:
+                transcript = client.audio.transcriptions.create(
+                    model="whisper-1", file=audio_file,
+                    response_format='verbose_json', timestamp_granularities=["segment"])
+            segments = ''
+            for s in transcript.segments:
+                segments += '{}\n'.format(s.text)
+            result['body'] = segments.strip()
+        except Exception as e:
+            logger.exception('Transcribe error:')
+            result['transcription_error'] = str(e)
+        finally:
+            return result
+
     def get_receive_message_values(self, params):
-        return {
+        values = {
             'message_sid': params.get('MessageSid'),
             'from_number': params.get('From'),
             'to_number': params.get('To'),
@@ -188,6 +219,15 @@ class ConnectMessage(models.Model):
             'media_content_type': params.get('MediaContentType0'),
             'media_url': params.get('MediaUrl0'),
         }
+        if params.get('MessageType') == 'audio':
+            transcript_voice_message = self.env['connect.settings'].sudo().get_param('transcript_voice_message')
+            openai_key = self.env['connect.settings'].sudo().get_param('openai_api_key')
+            if transcript_voice_message and openai_key:
+                transcription = self.transcribe_voice_message(openai_key, params.get('MediaUrl0'))
+                values.update(transcription)
+            elif transcript_voice_message and not openai_key:
+                logger.warning('OpenAI key is not set! Transcription will not be available.')
+        return values
 
     @api.model
     def receive(self, params):

--- a/connect/models/recording.py
+++ b/connect/models/recording.py
@@ -52,6 +52,11 @@ class Recording(models.Model):
     ############## TRANSCRIPTION METHODS #####################################
 
     def transcribe_recording(self, openai_api_key, summary_prompt):
+        # Check users summary prompt
+        if self.caller_user and self.caller_user.connect_user and self.caller_user.connect_user.summary_prompt:
+            summary_prompt = self.caller_user.connect_user.summary_prompt
+        elif self.called_user and self.called_user.connect_user and self.called_user.connect_user.summary_prompt:
+            summary_prompt = self.called_user.connect_user.summary_prompt
         result = {}
         temp_file_path = None
         try:
@@ -121,6 +126,11 @@ class Recording(models.Model):
 
     def get_transcript(self, fail_silently=False):
         self.ensure_one()
+        # Check if the call matches the transcription rules.
+        if fail_silently and not self.env['connect.transcription_rule'].sudo().check_rules(
+                self.call.caller, self.call.called):
+            debug(self, 'No transcription rules matched.')
+            return False
         openai_key = self.env['connect.settings'].sudo().get_param('openai_api_key')
         if not openai_key:
             if fail_silently:

--- a/connect/models/recording_transcription_rules.py
+++ b/connect/models/recording_transcription_rules.py
@@ -1,0 +1,33 @@
+import logging
+import re
+
+from odoo.addons.connect.models.settings import debug
+
+from odoo import models, fields, api
+
+logger = logging.getLogger(__name__)
+
+
+class TranscriptionRules(models.Model):
+    _name = 'connect.transcription_rule'
+    _description = 'Transcription rule'
+    _order = 'id'
+
+    settings = fields.Many2one('connect.settings', required=True, default=1)
+    calling_number = fields.Char(required=True)
+    called_number = fields.Char(required=True)
+
+    @api.model
+    def check_rules(self, calling_number, called_number):
+        for rec in self.search([]):
+            try:
+                if calling_number and not re.search(rec.calling_number, calling_number):
+                    debug(self, 'Transcription rule {} calling number pattern does not match'.format(rec.id))
+                    continue
+                if called_number and not re.search(rec.called_number, called_number):
+                    debug(self, 'Transcription rule {} called number pattern does not match'.format(rec.id))
+                    continue
+                debug(self, 'Transcription rule {} matched!'.format(rec.id))
+                return True
+            except Exception as e:
+                logger.error('Error checking transcription rule %s: %s', rec.id, e)

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -139,6 +139,10 @@ class Settings(models.Model):
     register_summary = fields.Boolean(
         default=True, help="Register summary at partner of reference chat."
     )
+    transcription_rules = fields.One2many('connect.transcription_rule', 'settings')
+    transcript_voice_message = fields.Boolean(default=True)
+    chatter_message_generate_prompt = fields.Text(
+        default='Continue the conversation naturally!', string='Message Generate Prompt')
     fetch_call_prices = fields.Boolean(
         default=False,
         string="Fetch Call Prices",
@@ -710,7 +714,10 @@ class Settings(models.Model):
             rec.mobile = rec._normalize_phone(rec.mobile)
 
     def compute_sip_uri(self, user):
-        return "sip:{}".format(self.env.user.connect_user.uri)
+        uri = "sip:{}".format(self.env.user.connect_user.uri)
+        if user.connect_user.auto_answer_header:
+            uri = f'{uri}?{user.connect_user.auto_answer_header}'
+        return uri
 
     def get_external_call_route(self, number, callerId, status_url,
             record='do-not-record', record_status_url=None):

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -20,6 +20,11 @@ from .twiml import pretty_xml
 
 logger = logging.getLogger(__name__)
 
+AUTO_ANSWER_HEADERS = [
+    ('X-AUTOANSWER=TRUE', 'X-AUTOANSWER=TRUE'),
+    ('Call-Info=answer-after%3D0', 'Call-Info=answer-after=0'),
+    ('Call-Info=Auto%20Answer', 'Call-Info=Auto Answer'),
+]
 
 SIP_TWILIO_EDGES = TWILIO_EDGES.copy()
 SIP_TWILIO_EDGES.insert(0, ['roaming', 'Global Low-latency Roaming'])
@@ -77,6 +82,12 @@ class User(models.Model):
     whatsapp_sender_id = fields.Many2one('connect.whatsapp_sender', string='WhatsApp Sender', ondelete='set null',
         domain="[('no_sync', '=', False), ('status', '=', 'ONLINE')]")
     missed_calls_notify = fields.Boolean(default=False, help='Notify user on missed calls.')
+    auto_answer_header = fields.Selection(AUTO_ANSWER_HEADERS)
+    fallback_destination = fields.Selection([
+        ('mobile', 'Mobile'),
+    ])
+    fallback_destination_mobile = fields.Char('Mobile Phone')
+    fallback_destination_exten = fields.Many2one('connect.exten')
     call_popup_is_enabled = fields.Boolean(default=True, string='Enable Call Notifications', help='Enable notifications for call events')
     call_popup_is_sticky = fields.Boolean(default=False, string='Sticky Call Notifications', help='Require manual dismissal of call notifications?')
     greeting_message = fields.Char()
@@ -725,6 +736,53 @@ class User(models.Model):
             self._manage_channel_callflow('client', True)
         else:
             self._manage_channel_callflow('client', False)
+
+    def render_fallback_destination(self, response, request, params):
+        if self.fallback_destination:
+            api_url = self.env['connect.settings'].sudo().get_param('api_url')
+            record_status_url = urljoin(api_url, 'twilio/webhook/recordingstatus')
+            status_url = urljoin(api_url, 'twilio/webhook/callstatus')
+            dial_action_url = urljoin(api_url, 'twilio/webhook/connect.user/call_action/{}'.format(self.id))
+            if self.fallback_destination == 'mobile':
+                dial_mobile_kwargs = {
+                    'timeout': 60,
+                    'callerId': self.outgoing_callerid.number,
+                }
+                if params.get('dial_action_url'):
+                    dial_mobile_kwargs['action'] = params['dial_action_url']
+                else:
+                    dial_mobile_kwargs['action'] = dial_action_url
+                if self.record_calls:
+                    dial_mobile_kwargs.update({
+                        'recordingStatusCallback': record_status_url,
+                        'record': 'record-from-answer-dual'
+                    })
+                dial = Dial('+{}'.format(strip_number(
+                    self.fallback_destination_mobile)), **dial_mobile_kwargs)
+                response.say('Connecting...')
+                response.append(dial)
+            elif self.fallback_destination == 'exten':
+                raise Exception('Not implemented')
+
+    @api.onchange('fallback_destination')
+    def _set_fallback_destination_mobile(self):
+        if self.fallback_destination == 'mobile' and not self.fallback_destination_mobile:
+            self.fallback_destination_mobile = self.user.partner_id.mobile
+
+    @api.constrains('fallback_destination')
+    def _manage_fallback_destination_callflow(self):
+        if self.fallback_destination:
+            if not self.env['connect.user_callflow'].search(
+                    [('user', '=', self.id), ('callflow_type', '=', 'fallback_destination')]):
+                self.env['connect.user_callflow'].create({
+                    'user': self.id,
+                    'prio': 5,
+                    'callflow_type': 'fallback_destination',
+                    'method': 'render_fallback_destination'
+                })
+        else:
+            self.env['connect.user_callflow'].search(
+                [('user', '=', self.id), ('callflow_type', '=', 'fallback_destination')]).unlink()
 
     @api.constrains('voicemail_enabled')
     def _manage_voicemail_enabled(self):

--- a/connect/security/admin.xml
+++ b/connect/security/admin.xml
@@ -252,4 +252,15 @@
   </record>
 
 
+  <!-- Transcription rules -->
+  <record id="connect_transcription_rule_admin" model="ir.model.access">
+    <field name="name">connect_transcription_rule_admin</field>
+    <field name="model_id" ref="connect.model_connect_transcription_rule"/>
+    <field name="group_id" ref="connect.group_connect_admin"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="1"/>
+    <field name="perm_create" eval="1"/>
+    <field name="perm_unlink" eval="1"/>
+  </record>
+
 </odoo>

--- a/connect/security/user.xml
+++ b/connect/security/user.xml
@@ -218,6 +218,17 @@
     <field name="perm_unlink" eval="0"/>
   </record>
 
+  <!-- Transcription rules -->
+  <record id="connect_transcription_rule_user" model="ir.model.access">
+    <field name="name">connect_transcription_rule_user</field>
+    <field name="model_id" ref="connect.model_connect_transcription_rule"/>
+    <field name="group_id" ref="connect.group_connect_user"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="0"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
   <!-- Message Content Template -->
   <record id="connect_message_content_template_user" model="ir.model.access">
     <field name="name">connect_message_content_template_user</field>

--- a/connect/static/src/core/common/composer.js
+++ b/connect/static/src/core/common/composer.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+"use strict"
+
+import {patch} from "@web/core/utils/patch"
+import {Composer} from "@mail/core/common/composer"
+
+
+patch(Composer.prototype, {
+    async _onClickAiCompletion() {
+        const response = await this.rpc("/connect/ai_completion", {
+            model: this.thread.model,
+            res_id: this.thread.id,
+        })
+        if (response.status === 'ok') {
+            this.props.composer.textInputContent = response.message
+        } else {
+            this.env.services.notification.add(response.error_message, {type: "warning",})
+        }
+    }
+})

--- a/connect/static/src/core/common/composer.xml
+++ b/connect/static/src/core/common/composer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-inherit="mail.Composer" t-inherit-mode="extension">
+        <xpath expr="//FileUploader" position="after">
+            <button class="btn border-0 rounded-pill" t-on-click="_onClickAiCompletion" title="AI Completion" aria-label="AI Completion" type="button">
+                <i class="fa fa-microchip"/>
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/connect/views/call.xml
+++ b/connect/views/call.xml
@@ -143,6 +143,8 @@
                               invisible="voicemail_widget == ''">
                             <group>
                                 <field name="voicemail_widget" widget="html"/>
+                                <field name="voicemail_transcript" string="Transcript"/>
+                                <field name="voicemail_transcription_error" invisible="not voicemail_transcription_error" string="Transcript Error"/>
                             </group>
                         </page>
                         <page name="channels" string="Channels" groups="base.group_no_one">

--- a/connect/views/callflow.xml
+++ b/connect/views/callflow.xml
@@ -21,6 +21,7 @@
                 <field name="name"/>
                 <field name="exten_number" string="Exten"/>
                 <field name="record_calls"/>
+                <field name="ring_contact_manager" string="Contact Manager"/>
             </tree>
         </field>
     </record>
@@ -56,12 +57,17 @@
                                     <field name="speech"/>
                                 </tree>
                             </field>
+                            <field name="calendar"/>
+                            <field name="off_calendar_callflow" invisible="calendar == False" required="calendar != False" domain="[('id', '!=', id)]"/>
                         </group>
                         <group>
                             <div id="see_more" colspan="2">
                                 <small>See available voices <a target="_new" href="https://www.twilio.com/docs/voice/twiml/say/text-speech#available-voices-and-languages">here</a></small>
                             </div>
                             <field name="voice" placeholder="man"/>
+                            <field name="ring_contact_manager"/>
+                            <field name="ring_contact_manager_timeout" invisible="ring_contact_manager != True"/>
+                            <field name="ring_contact_manager_prompt" invisible="ring_contact_manager != True"/>
                             <field name="ring_users" widget="many2many_tags"/>
                             <field name="record_calls"/>
                             <field name="voicemail_enabled"/>

--- a/connect/views/message.xml
+++ b/connect/views/message.xml
@@ -118,6 +118,7 @@
                             <field name="media_url" invisible="1"/>
                             <field name="media_widget" widget="html" invisible="media_url == False"/>
                             <field name="error_message" invisible="not error_message"/>
+                            <field name="transcription_error" invisible="not transcription_error"/>
                         </group>
                     </group>
                     <notebook>

--- a/connect/views/settings.xml
+++ b/connect/views/settings.xml
@@ -86,8 +86,25 @@
                           invisible="transcript_calls == False"/>
                     <field name="register_summary"
                            invisible="transcript_calls == False"/>
+                    <field name="transcript_voice_message" string="Transcribe Voice Messages"/>
                    </group>
+                    <group string="Transcribe Rules"
+                           invisible="transcript_calls == False">
+                        <field name="transcription_rules" nolabel="1" colspan="2">
+                            <tree editable="bottom">
+                                <field name="calling_number"/>
+                                <field name="called_number"/>
+                            </tree>
+                        </field>
+                    </group>
                   </group>
+                </page>
+                <page name="chatter" string="Chatter" invisible="is_registered == False">
+                    <group>
+                        <group>
+                            <field name="chatter_message_generate_prompt"/>
+                        </group>
+                    </group>
                 </page>
                 <page string="Development" groups="base.group_no_one"
                       invisible="is_registered == False">

--- a/connect/views/user.xml
+++ b/connect/views/user.xml
@@ -91,10 +91,18 @@
                                     <field name="outgoing_callerid" placeholder="Outgoing CallerId number or empty for the default..."/>
                                     <field name="whatsapp_sender_id"/>
                                     <field name="record_calls"/>
-                                    <field name="summary_prompt" string="Record Summary Prompt"
-                                           readonly="1" help="Enterprise Feature"/>
+                                    <field name="summary_prompt" string="Record Summary Prompt"/>
                                 </group>
                                 <group>
+                                    <field name="fallback_destination"/>
+                                    <field name="fallback_destination_mobile"
+                                        invisible="fallback_destination != 'mobile'"
+                                        required="fallback_destination == 'mobile'"
+                                    />
+                                    <field name="fallback_destination_exten" string="Exten"
+                                        invisible="fallback_destination != 'exten'"
+                                        required="fallback_destination == 'exten'"
+                                    />
                                     <field name="voicemail_enabled"/>
                                     <field name="voicemail_prompt"
                                            invisible="not voicemail_enabled"
@@ -107,6 +115,7 @@
                             <group>
                                 <group>
                                     <field name="missed_calls_notify"/>
+                                    <field name="auto_answer_header"/>
                                 </group>
                             </group>
                         </page>

--- a/connect_elevenlabs_knowledge/views/agent.xml
+++ b/connect_elevenlabs_knowledge/views/agent.xml
@@ -9,13 +9,13 @@
             <page name="llm" position="after">
                 <page name="knowledge_base" string="Knowledge Base">
                     <field name="knowledge_base" nolabel="1">
-                        <list>
+                        <tree>
                             <field name="name"/>
                             <field name="document_type"/>
                             <field name="state" decoration-success="state == 'active'" decoration-danger="state == 'error'"/>
                             <field name="document_size" optional="show"/>
                             <field name="updated_at" optional="show"/>
-                        </list>
+                        </tree>
                     </field>
                 </page>
             </page>

--- a/connect_elevenlabs_knowledge/views/knowledge.xml
+++ b/connect_elevenlabs_knowledge/views/knowledge.xml
@@ -5,7 +5,7 @@
         <field name="name">connect.elevenlabs_knowledge.list</field>
         <field name="model">connect.elevenlabs_knowledge</field>
         <field name="arch" type="xml">
-            <list string="Knowledge Base">
+            <tree string="Knowledge Base">
                 <field name="name"/>
                 <field name="document_type"/>
                 <field name="state" decoration-success="state == 'active'" decoration-danger="state == 'error'" decoration-warning="state == 'creating'"/>
@@ -13,7 +13,7 @@
                 <field name="document_size" optional="show"/>
                 <field name="updated_at" optional="show"/>
                 <field name="knowledge_id" optional="hide"/>
-            </list>
+            </tree>
         </field>
     </record>
 
@@ -80,12 +80,12 @@
                                 <field name="agent_count" readonly="1"/>
                             </group>
                             <field name="agent_ids" nolabel="1">
-                                <list>
+                                <tree>
                                     <field name="name"/>
                                     <field name="language"/>
                                     <field name="llm"/>
                                     <field name="voice"/>
-                                </list>
+                                </tree>
                             </field>
                         </page>
                     </notebook>


### PR DESCRIPTION
## Summary
- **Ring Contact Manager**: callflow option to route incoming calls to the caller's assigned sales manager before falling to the general queue
- **Calendar-based routing**: callflow support for business hours with off-calendar fallback
- **Transcription rules**: regex-based rules to control which calls get transcribed, plus voicemail transcription via OpenAI Whisper
- **AI chatter completion**: OpenAI-powered message generation button in the Odoo mail composer
- **Fallback destinations**: user-level fallback routing to mobile when SIP client is unavailable
- **Auto-answer SIP headers**: configurable auto-answer header per PBX user
- **Per-user summary prompts**: unlocked custom summary prompts per connect user (previously enterprise-only)
- **German translation**: added `de.po` for the connect module
- **Misc fixes**: `<tree>` tag compatibility for 17.0, httpx dependency removal, callflow render loop fix

## Test plan
- [ ] Enable "Connect to Manager" on a callflow and verify calls from known contacts route to their manager first
- [ ] Configure a calendar on a callflow and test outside-hours routing
- [ ] Add transcription rules and verify only matching calls are transcribed
- [ ] Test AI completion button in chatter composer
- [ ] Set a fallback destination (mobile) on a PBX user and verify fallback behavior
- [ ] Verify auto-answer header is sent in SIP URI when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)