### PR TITLE
fix: use <tree> instead of <list> in pbx_group views for 17.0

### DIFF
--- a/connect/views/pbx_group.xml
+++ b/connect/views/pbx_group.xml
@@ -4,10 +4,10 @@
         <field name="name">connect.pbx_group.tree</field>
         <field name="model">connect.pbx_group</field>
         <field name="arch" type="xml">
-            <list>
+            <tree>
                 <field name="name"/>
                 <field name="users" widget="many2many_tags"/>
-            </list>
+            </tree>
         </field>
     </record>
 
@@ -33,7 +33,7 @@
     <record id="connect_pbx_group_action" model="ir.actions.act_window">
         <field name="name">PBX Groups</field>
         <field name="res_model">connect.pbx_group</field>
-        <field name="view_mode">list,form</field>
+        <field name="view_mode">tree,form</field>
     </record>
 
     <menuitem id="connect_pbx_group_menu" name="PBX Groups"


### PR DESCRIPTION
Odoo 17.0 does not recognize `<list>` as a valid view type, causing module installation to fail with `Wrong value for ir.ui.view.type: 'list'`. Changed to `<tree>` and `tree,form` view_mode.