### PR TITLE
fix: notify followers on incoming SMS (15.0)

### DIFF
--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -336,10 +336,10 @@ class ConnectMessage(models.Model):
                                           f"<br/>{message.media_widget}</div>")
 
                         # Post as a comment to notify subscribed followers similar to incoming mail
-                        mt_note = self.env.ref('mail.mt_note').id
+                        mt_comment = self.env.ref('mail.mt_comment').id
                         kwargs = {
                             'body': body,
-                            'subtype_id': mt_note,
+                            'subtype_id': mt_comment,
                             'message_type': message.message_type
                         }
                         if partner:


### PR DESCRIPTION
## Summary
- Changed incoming SMS chatter subtype from `mail.mt_note` to `mail.mt_comment`
- Followers of a record now receive inbox notifications when a customer replies via SMS

## Test plan
- Send SMS from a record (lead/sale order/partner)
- Have customer reply
- Verify followers see notification in inbox