### PR TITLE
feat: call parking and unparking via Twilio Queue (*701-*710)

### DIFF
--- a/connect/data/twiml.xml
+++ b/connect/data/twiml.xml
@@ -32,7 +32,7 @@
         <field name="code_type">model_method</field>
         <field name="model">connect.call</field>
         <field name="method">park_call</field>
-        <field name="description">Parks the current call into a free parking slot (701-710)</field>
+        <field name="description">Parks the current call into a specific parking slot (*701-*710)</field>
     </record>
 
     <record id="twiml_unpark_call" model="connect.twiml">
@@ -43,8 +43,53 @@
         <field name="description">Retrieves a parked call from the specified parking slot</field>
     </record>
 
-    <record id="exten_park" model="connect.exten">
-        <field name="number">700</field>
+    <record id="exten_park_701" model="connect.exten">
+        <field name="number">*701</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_702" model="connect.exten">
+        <field name="number">*702</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_703" model="connect.exten">
+        <field name="number">*703</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_704" model="connect.exten">
+        <field name="number">*704</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_705" model="connect.exten">
+        <field name="number">*705</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_706" model="connect.exten">
+        <field name="number">*706</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_707" model="connect.exten">
+        <field name="number">*707</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_708" model="connect.exten">
+        <field name="number">*708</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_709" model="connect.exten">
+        <field name="number">*709</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+    <record id="exten_park_710" model="connect.exten">
+        <field name="number">*710</field>
         <field name="model">connect.twiml</field>
         <field name="res_id" ref="twiml_park_call"/>
     </record>

--- a/connect/data/twiml.xml
+++ b/connect/data/twiml.xml
@@ -26,4 +26,78 @@
 &lt;/Response&gt;</field>
     </record>
 
+    <!-- Call Parking -->
+    <record id="twiml_park_call" model="connect.twiml">
+        <field name="name">Park Call</field>
+        <field name="code_type">model_method</field>
+        <field name="model">connect.call</field>
+        <field name="method">park_call</field>
+        <field name="description">Parks the current call into a free parking slot (701-710)</field>
+    </record>
+
+    <record id="twiml_unpark_call" model="connect.twiml">
+        <field name="name">Unpark Call</field>
+        <field name="code_type">model_method</field>
+        <field name="model">connect.call</field>
+        <field name="method">unpark_call</field>
+        <field name="description">Retrieves a parked call from the specified parking slot</field>
+    </record>
+
+    <record id="exten_park" model="connect.exten">
+        <field name="number">700</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_park_call"/>
+    </record>
+
+    <record id="exten_unpark_701" model="connect.exten">
+        <field name="number">701</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_702" model="connect.exten">
+        <field name="number">702</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_703" model="connect.exten">
+        <field name="number">703</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_704" model="connect.exten">
+        <field name="number">704</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_705" model="connect.exten">
+        <field name="number">705</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_706" model="connect.exten">
+        <field name="number">706</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_707" model="connect.exten">
+        <field name="number">707</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_708" model="connect.exten">
+        <field name="number">708</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_709" model="connect.exten">
+        <field name="number">709</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+    <record id="exten_unpark_710" model="connect.exten">
+        <field name="number">710</field>
+        <field name="model">connect.twiml</field>
+        <field name="res_id" ref="twiml_unpark_call"/>
+    </record>
+
 </data></odoo>

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -1465,70 +1465,21 @@ class Call(models.Model):
             "call_pattern"
         ]
 
-    PARK_SLOTS = range(701, 711)  # Parking slots 701-710 (Asterisk-style)
-
     @api.model
     def park_call(self, request, params):
-        """Park a call into a free parking slot (701-710).
+        """Park a call into a specific parking slot.
 
-        Called via SIP REFER when agent dials 700.
+        Called via SIP REFER when agent dials *701-*710.
+        The slot number is derived from the extension number (e.g. *701 -> 701).
         In referUrl context, CallSid = parent call (customer's inbound call).
         The returned TwiML applies to the customer's call.
         """
-        self = self.sudo()
-        customer_call_sid = request.get('CallSid')
-        debug(self, 'park_call: CallSid=%s' % customer_call_sid)
+        exten = params.get('ExtenNumber', '')
+        slot = exten.lstrip('*')
+        debug(self, 'park_call: Parking CallSid=%s on slot %s' % (request.get('CallSid'), slot))
 
-        # Find a free parking slot via Twilio REST API
-        client = self.env['connect.settings'].get_client()
-        occupied_slots = set()
-        try:
-            queues = client.queues.list()
-            for q in queues:
-                if q.friendly_name.startswith('park-') and q.current_size > 0:
-                    try:
-                        slot_num = int(q.friendly_name.split('-')[1])
-                        if slot_num in self.PARK_SLOTS:
-                            occupied_slots.add(slot_num)
-                    except (ValueError, IndexError):
-                        pass
-        except Exception as e:
-            logger.error('park_call: Failed to list queues: %s', e)
-
-        free_slot = None
-        for slot in self.PARK_SLOTS:
-            if slot not in occupied_slots:
-                free_slot = slot
-                break
-
-        if not free_slot:
-            response = VoiceResponse()
-            response.say('All parking slots are busy.', language='en-US')
-            return response
-
-        # Find the agent's channel to announce the slot number
-        customer_channel = self.env['connect.channel'].search(
-            [('sid', '=', customer_call_sid)], limit=1)
-        if customer_channel and customer_channel.call:
-            agent_channels = customer_channel.call.channels.filtered(
-                lambda c: c.sid != customer_call_sid and c.status not in CALL_END_STATUSES
-            )
-            if agent_channels:
-                try:
-                    slot_digits = ' '.join(str(free_slot))
-                    announce = VoiceResponse()
-                    announce.say('Parked on %s' % slot_digits, language='en-US')
-                    announce.hangup()
-                    client.calls(agent_channels[0].sid).update(twiml=str(announce))
-                    debug(self, 'park_call: Announced slot %s to agent channel %s' % (
-                        free_slot, agent_channels[0].sid))
-                except Exception as e:
-                    logger.error('park_call: Failed to announce to agent: %s', e)
-
-        # Return TwiML for the customer's call: enqueue into parking slot
         response = VoiceResponse()
-        response.enqueue('park-%s' % free_slot)
-        debug(self, 'park_call: Parking customer %s in slot %s' % (customer_call_sid, free_slot))
+        response.enqueue('park-%s' % slot)
         return response
 
     @api.model

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -1493,7 +1493,7 @@ class Call(models.Model):
         debug(self, 'unpark_call: Retrieving from slot %s' % slot)
 
         response = VoiceResponse()
-        dial = Dial(timeout=3)
+        dial = Dial(timeout=1)
         dial.queue('park-%s' % slot)
         response.append(dial)
         response.say('No parked call on this slot.', language='en-US')

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -1493,7 +1493,7 @@ class Call(models.Model):
         debug(self, 'unpark_call: Retrieving from slot %s' % slot)
 
         response = VoiceResponse()
-        dial = Dial()
+        dial = Dial(timeout=3)
         dial.queue('park-%s' % slot)
         response.append(dial)
         response.say('No parked call on this slot.', language='en-US')

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -1464,3 +1464,86 @@ class Call(models.Model):
             "transferred_users",
             "call_pattern"
         ]
+
+    PARK_SLOTS = range(701, 711)  # Parking slots 701-710 (Asterisk-style)
+
+    @api.model
+    def park_call(self, request, params):
+        """Park a call into a free parking slot (701-710).
+
+        Called via SIP REFER when agent dials 700.
+        In referUrl context, CallSid = parent call (customer's inbound call).
+        The returned TwiML applies to the customer's call.
+        """
+        self = self.sudo()
+        customer_call_sid = request.get('CallSid')
+        debug(self, 'park_call: CallSid=%s' % customer_call_sid)
+
+        # Find a free parking slot via Twilio REST API
+        client = self.env['connect.settings'].get_client()
+        occupied_slots = set()
+        try:
+            queues = client.queues.list()
+            for q in queues:
+                if q.friendly_name.startswith('park-') and q.current_size > 0:
+                    try:
+                        slot_num = int(q.friendly_name.split('-')[1])
+                        if slot_num in self.PARK_SLOTS:
+                            occupied_slots.add(slot_num)
+                    except (ValueError, IndexError):
+                        pass
+        except Exception as e:
+            logger.error('park_call: Failed to list queues: %s', e)
+
+        free_slot = None
+        for slot in self.PARK_SLOTS:
+            if slot not in occupied_slots:
+                free_slot = slot
+                break
+
+        if not free_slot:
+            response = VoiceResponse()
+            response.say('All parking slots are busy.', language='en-US')
+            return response
+
+        # Find the agent's channel to announce the slot number
+        customer_channel = self.env['connect.channel'].search(
+            [('sid', '=', customer_call_sid)], limit=1)
+        if customer_channel and customer_channel.call:
+            agent_channels = customer_channel.call.channels.filtered(
+                lambda c: c.sid != customer_call_sid and c.status not in CALL_END_STATUSES
+            )
+            if agent_channels:
+                try:
+                    slot_digits = ' '.join(str(free_slot))
+                    announce = VoiceResponse()
+                    announce.say('Parked on %s' % slot_digits, language='en-US')
+                    announce.hangup()
+                    client.calls(agent_channels[0].sid).update(twiml=str(announce))
+                    debug(self, 'park_call: Announced slot %s to agent channel %s' % (
+                        free_slot, agent_channels[0].sid))
+                except Exception as e:
+                    logger.error('park_call: Failed to announce to agent: %s', e)
+
+        # Return TwiML for the customer's call: enqueue into parking slot
+        response = VoiceResponse()
+        response.enqueue('park-%s' % free_slot)
+        debug(self, 'park_call: Parking customer %s in slot %s' % (customer_call_sid, free_slot))
+        return response
+
+    @api.model
+    def unpark_call(self, request, params):
+        """Unpark (retrieve) a call from a parking slot.
+
+        Called when someone dials extension 701-710.
+        params['ExtenNumber'] contains the slot number.
+        """
+        slot = params.get('ExtenNumber', '')
+        debug(self, 'unpark_call: Retrieving from slot %s' % slot)
+
+        response = VoiceResponse()
+        dial = Dial()
+        dial.queue('park-%s' % slot)
+        response.append(dial)
+        response.say('No parked call on this slot.', language='en-US')
+        return response


### PR DESCRIPTION
## Summary

- Add Asterisk-style call parking using Twilio Queue: agent dials `*701`-`*710` (via SIP REFER) to park a call on a specific slot, another agent dials `701`-`710` to retrieve it.
- `park_call` method enqueues the customer into `park-{slot}` queue with hold music.
- `unpark_call` method dials the queue with a 1s timeout; falls back to "No parked call" message if the slot is empty.
- 20 new extensions in `twiml.xml`: 10 park (`*701`-`*710`) and 10 unpark (`701`-`710`), all pointing to shared `model_method` TwiML records.

## Test plan
- [ ] Park a call via SIP REFER to `*703` — customer should hear hold music
- [ ] Unpark by dialing `703` — agent connects to the parked caller
- [ ] Dial an empty slot (e.g. `704`) — hear "No parked call on this slot" after ~1s