### PR TITLE
fix: use version-aware route_type for /connect/ai_completion

### DIFF
--- a/connect/controllers/main.py
+++ b/connect/controllers/main.py
@@ -313,7 +313,7 @@ class ConnectController(http.Controller):
         except Exception as e:
             logger.error(f'Failed to store external termination context: {e}')
 
-    @http.route("/connect/ai_completion", type="json", auth="user")
+    @http.route("/connect/ai_completion", type=route_type, auth="user")
     def ai_completion(self, model, res_id):
         openai_api_key = http.request.env["connect.settings"].sudo().get_param("openai_api_key")
         if not openai_api_key:


### PR DESCRIPTION
## Summary
- `/connect/ai_completion` was the only route in the module still hard-coding `type="json"`, which triggers a DeprecationWarning on Odoo 19.0 (`@route(type='json')` is now an alias for `@route(type='jsonrpc')`).
- Switched the decorator to `type=route_type` so it uses the module-level version-aware helper already used by every other route in `connect_addons`.
- No behavior change on 18.0 (`route_type == "json"`); the warning disappears on 19.0.

## Test plan
- [ ] Load `connect` on Odoo 19.0 — no `@route(type='json')` DeprecationWarning in logs.
- [ ] On 18.0, click AI-completion in the chatter composer — `/connect/ai_completion` still returns a completion.