### PR TITLE
[18.0] Backport connect calls improvements (S3 recordings, do-not-record, has_activity, auto-reload, live status)

### DIFF
--- a/.github/workflows/addons.yml
+++ b/.github/workflows/addons.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@master
       - name: Install module requirements
-        run: pip3 install twilio elevenlabs openai==1.39.0 typing_extensions==4.10.0 --break-system-packages
+        run: pip3 install twilio elevenlabs openai==1.39.0 typing_extensions==4.10.0 boto3 --break-system-packages
       - name: Install odoo modules
         run: >
           odoo --addons-path=$GITHUB_WORKSPACE --database=ephemeral

--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -15,7 +15,7 @@
     "description": "",
     "depends": ["mail", "contacts", "sms", "resource"],
     "external_dependencies": {
-        "python": ["twilio", "openai", "PyJWT"],
+        "python": ["twilio", "openai", "PyJWT", "boto3"],
     },
     "sequences": True,
     "data": [

--- a/connect/controllers/main.py
+++ b/connect/controllers/main.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import NotFound
 from odoo import fields, http, release, tools
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import UserError
+from odoo.addons.connect.models import s3_utils
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +54,22 @@ class ConnectController(http.Controller):
         return self._serve_media(call.voicemail_url)
 
     def _serve_media(self, media_url):
+        settings = http.request.env['connect.settings'].sudo()
+        bucket = settings.get_param('aws_s3_bucket_name')
+        if settings.get_param('s3_recordings_enabled') and s3_utils.is_s3_media_url(media_url, bucket):
+            key = s3_utils.parse_s3_key(media_url, bucket)
+            s3 = settings._get_s3_client()
+            try:
+                obj = s3.get_object(Bucket=bucket, Key=key)
+            except s3.exceptions.NoSuchKey:
+                return http.Response(status=410)  # gone (lifecycle-expired)
+            data = obj['Body'].read()
+            res = http.Response(data, content_type=obj.get('ContentType') or 'audio/mpeg')
+            res.headers['Content-Disposition'] = http.content_disposition(key.split('/')[-1])
+            return res
         media_name = '{}.wav'.format(media_url.split('/')[-1])
-        account_sid = http.request.env['connect.settings'].sudo().get_param('account_sid')
-        auth_token = http.request.env['connect.settings'].sudo().get_param('auth_token')
+        account_sid = settings.get_param('account_sid')
+        auth_token = settings.get_param('auth_token')
         response = requests.get(media_url, auth=(account_sid, auth_token))
         if response.status_code == 200:
             # Create the response

--- a/connect/docs/s3-recordings-setup.md
+++ b/connect/docs/s3-recordings-setup.md
@@ -1,0 +1,112 @@
+# Storing call recordings in AWS S3
+
+By default Twilio stores call recordings in Twilio's cloud and Odoo plays them from
+there. You can instead store recordings in your own AWS S3 bucket and control how long
+they are kept. This keeps the media under your control and removes Twilio storage costs.
+
+How it works: Twilio uploads each new recording directly to your S3 bucket; Odoo reads
+and plays it back from S3. Recordings created before you switch stay on Twilio and keep
+working (mixed mode).
+
+> **Note (voice):** Twilio has **no API** to enable external storage for *voice*
+> recordings — the final enable step is done once in the Twilio Console. Odoo automates
+> everything else (bucket creation, the Twilio AWS credential, the ready-to-paste URL).
+
+---
+
+## 1. AWS — create one IAM user
+
+Create a single IAM user (programmatic access) and attach this least-privilege policy.
+It lets Odoo create/configure the bucket and read recordings, and lets Twilio write them.
+No `iam:*` permissions are granted, so the key is not an admin key. The bucket-name prefix
+(`oduist-connect-*`) limits which buckets the key can touch. Odoo adds this prefix to your
+bucket name automatically, so you only enter a suffix (e.g. `recordings-acme`).
+
+The prefix is configurable in **Connect Settings → S3 Storage → S3 Bucket Prefix**
+(default `oduist-connect-`); set your own to match an existing IAM naming convention. The
+policy shown on that page is generated from the prefix you choose, so it always matches —
+copy it straight from there instead of the static example below.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CreateAndConfigureBucket",
+      "Effect": "Allow",
+      "Action": ["s3:CreateBucket", "s3:PutBucketPublicAccessBlock",
+                 "s3:PutEncryptionConfiguration", "s3:PutLifecycleConfiguration",
+                 "s3:GetBucketLocation"],
+      "Resource": "arn:aws:s3:::oduist-connect-*"
+    },
+    {
+      "Sid": "ReadWriteObjects",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject", "s3:ListBucket",
+                 "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts",
+                 "s3:ListBucketMultipartUploads"],
+      "Resource": ["arn:aws:s3:::oduist-connect-*",
+                   "arn:aws:s3:::oduist-connect-*/*"]
+    }
+  ]
+}
+```
+
+Step by step in the AWS Console:
+
+1. **IAM → Users → Create user** — give it a name (e.g. `connect-s3`).
+2. On **Set permissions**, choose **Attach policies directly → Create policy → JSON**,
+   paste the policy above, name it (e.g. `connect-s3-recordings`), create it and attach it
+   to the user.
+3. Open the user → **Security credentials → Create access key** → *Application running
+   outside AWS* → copy the **Access Key ID** and **Secret access key**.
+
+(The same policy and these steps are shown directly in Odoo on the S3 Storage settings
+page, generated from your chosen prefix — copy them from there.)
+
+## 2. Odoo — Connect Settings → S3 Storage
+
+First tick **Store recordings in S3** — this reveals the S3 settings below. Then:
+
+1. Keep the default **S3 Bucket Prefix** (`oduist-connect-`) or set your own; the IAM
+   policy shown updates to match. Copy that policy and attach it to the IAM user (section 1).
+2. Enter the **AWS Access Key ID** and **AWS Secret Access Key**.
+3. Pick the **AWS Region** (e.g. `eu-central-1` for EU/GDPR). The region is permanent for
+   the bucket.
+4. Enter an **S3 Bucket Name** suffix (globally unique, e.g. `recordings-<yourcompany>`).
+   Odoo prepends the bucket prefix automatically to match the IAM policy. Also set a
+   **Folder (prefix)** (default `recordings`).
+5. Set **Retention (days)** — `0` keeps recordings forever; `N` deletes the audio file
+   after N days (the recording row and its transcript are kept; the player shows
+   "Recording expired").
+6. Click **Create / configure S3 bucket** — Odoo creates the bucket, blocks public access,
+   enables encryption, and applies the retention lifecycle rule.
+7. Click **Create Twilio AWS credential** — Odoo registers your AWS key with Twilio and
+   stores the resulting credential SID (`CR…`). You do **not** paste AWS keys into Twilio.
+
+## 3. Twilio Console — enable external storage (one time)
+
+1. Twilio Console → **Voice → Recordings → Settings**.
+2. Enable **external S3 storage**.
+3. Select the AWS credential **connect-s3-recordings** (the SID shown in Odoo).
+4. Paste the **S3 URL** shown in Odoo (the read-only "S3 URL (paste into Twilio)" field).
+5. **Save**.
+
+## 4. Odoo — it's already on
+
+**Store recordings in S3** was switched on in step 2 to reveal the settings, so there is
+nothing more to toggle. Recordings that Twilio uploads to your bucket are now read from
+S3; older (pre-switch) recordings keep playing from Twilio.
+
+## 5. Verify
+
+Make a short recorded call. Confirm a new object appears under `recordings/` in your
+bucket, and the recording plays back inside Odoo. Old (pre-switch) recordings still play
+from Twilio.
+
+## Retention
+
+Retention is enforced by an S3 lifecycle rule on the bucket. After N days AWS deletes the
+audio object; Odoo keeps the recording record (and transcript/summary) and shows
+"Recording expired" in the player. Change the period by updating **Retention (days)** and
+clicking **Create / configure S3 bucket** again.

--- a/connect/models/__init__.py
+++ b/connect/models/__init__.py
@@ -8,6 +8,7 @@ Modification is prohibited under Oduist Proprietary License.
 See LICENSE and COPYRIGHT files for full terms.
 """
 
+from . import s3_utils
 from . import call
 from . import callflow
 from . import ir_module_module

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -21,8 +21,8 @@ from datetime import timedelta
 import openai
 import requests
 
-from odoo import fields, models, api, release, SUPERUSER_ID, tools
-from odoo.exceptions import ValidationError
+from odoo import fields, models, api, release, SUPERUSER_ID, tools, _
+from odoo.exceptions import ValidationError, AccessError
 from twilio.twiml.voice_response import VoiceResponse, Say, Dial, Conference, Client, Number, Sip
 from .settings import debug, MAX_EXTEN_LEN
 from .res_partner import strip_number
@@ -49,6 +49,9 @@ class Call(models.Model):
     else:
         recording_widget = fields.Char(compute='_get_recording_data')
     recording_icon = fields.Html(compute='_get_recording_data', string='R')
+    has_activity = fields.Boolean(string='A', compute='_compute_has_activity', store=True)
+    disable_recording = fields.Boolean(default=False,
+        help='When set, no recording is stored for this call when it ends.')
     summary = fields.Html()
     called = fields.Char(readonly=True, index=True)
     caller = fields.Char(readonly=True, index=True)
@@ -182,6 +185,21 @@ class Call(models.Model):
                 rec.transcript = ''
                 rec.recording = False
                 rec.recording_widget = ''
+
+    @api.depends('activity_ids')
+    def _compute_has_activity(self):
+        for rec in self:
+            rec.has_activity = bool(rec.activity_ids)
+
+    def _recompute_has_activity(self):
+        # mail.activity uses a generic (res_model, res_id) reference, so adding
+        # or removing an activity does not auto-trigger the activity_ids
+        # dependency above. Called from the mail.activity create/write/unlink
+        # overrides to keep the stored flag in sync (e.g. on "mark done").
+        calls = self.exists()
+        if calls:
+            calls.invalidate_recordset(['activity_ids'])
+            calls._compute_has_activity()
 
     def _get_voicemail_widget(self):
         proxy_recordings = self.env['connect.settings'].sudo().get_param('proxy_recordings')
@@ -335,6 +353,26 @@ class Call(models.Model):
             else:
                 self.status = 'no-answer'
                 logger.info(f"Call {self.id}: Status set to 'no-answer' (default)")
+
+    def _update_live_status(self):
+        """Reflect the live call status while the call is still active.
+
+        The call status is set on creation (ringing) and only finalized once all
+        channels end (_set_final_call_status). Without this, the status never moves
+        to 'in-progress' on answer. Derive it from the current channel statuses so
+        the UI shows ringing -> in-progress. Terminal statuses are left to
+        _set_final_call_status().
+        """
+        self.ensure_one()
+        chan_statuses = self.channels.mapped('status')
+        if 'in-progress' in chan_statuses:
+            live_status = 'in-progress'
+        elif 'ringing' in chan_statuses:
+            live_status = 'ringing'
+        else:
+            return
+        if self.status != live_status:
+            self.status = live_status
 
     def _populate_user_fields_direct_call(self):
         """Populate user fields for direct call pattern."""
@@ -872,6 +910,8 @@ class Call(models.Model):
             else:
                 reason = "channel not ending"
             logger.info(f"Call {channel.call.id}: Finalization deferred - {reason}")
+            # Call is still active: keep its status live (ringing -> in-progress).
+            channel.call._update_live_status()
         # Reload call view
         self.env['connect.settings'].connect_reload_view('connect.call')
         if params.get('ErrorCode') and params.get('ErrorCode') not in IGNORE_ERROR_CODES:
@@ -1462,8 +1502,29 @@ class Call(models.Model):
             "answered_user",
             "completed_by_user",
             "transferred_users",
-            "call_pattern"
+            "call_pattern",
+            "disable_recording",
         ]
+
+    @api.model
+    def set_disable_recording(self, call_id, value=True):
+        """Toggle the disable_recording flag on a call from the active calls widget.
+
+        Restricted to members of the "Do not record" group.
+        """
+        if not self.env.user.has_group('connect.group_connect_do_not_record'):
+            raise AccessError(_('You are not allowed to disable call recording.'))
+        call = self.browse(call_id)
+        call.sudo().disable_recording = bool(value)
+        return call.sudo().disable_recording
+
+    @api.model
+    def can_disable_recording(self):
+        """Whether the current user may disable recording from the active calls
+        widget: member of the "Do not record" group AND their own calls are
+        recorded (otherwise there is nothing to disable)."""
+        user = self.env.user
+        return user.has_group('connect.group_connect_do_not_record') and bool(user.connect_user.record_calls)
 
     @api.model
     def park_call(self, request, params):

--- a/connect/models/mail.py
+++ b/connect/models/mail.py
@@ -27,3 +27,29 @@ class MailNotification(models.Model):
     notification_type = fields.Selection(selection_add=[
         ('WhatsApp', 'WhatsApp')
     ], ondelete={'WhatsApp': 'cascade'})
+
+
+class MailActivity(models.Model):
+    _inherit = 'mail.activity'
+
+    def _connect_calls(self):
+        call_ids = {a.res_id for a in self if a.res_model == 'connect.call' and a.res_id}
+        return self.env['connect.call'].browse(call_ids)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        activities = super().create(vals_list)
+        activities._connect_calls()._recompute_has_activity()
+        return activities
+
+    def write(self, vals):
+        calls = self._connect_calls()
+        res = super().write(vals)
+        (calls | self._connect_calls())._recompute_has_activity()
+        return res
+
+    def unlink(self):
+        calls = self._connect_calls()
+        res = super().unlink()
+        calls._recompute_has_activity()
+        return res

--- a/connect/models/recording.py
+++ b/connect/models/recording.py
@@ -9,6 +9,7 @@ from odoo import fields, models, api, release
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from .settings import format_connect_response, debug
+from . import s3_utils
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ class Recording(models.Model):
     duration_human = fields.Char(compute='_get_duration_human')
     start_time = fields.Datetime()
     status = fields.Char()
+    recording_expired = fields.Boolean(compute='_compute_recording_expired')
     if release.version_info[0] >= 17.0:
         recording_widget = fields.Html(compute='_get_recording_widget', string='Recording', sanitize=False)
     else:
@@ -64,6 +66,12 @@ class Recording(models.Model):
                         users |= group.user_ids
             rec.pbx_group_user_ids = users
 
+    def _compute_recording_expired(self):
+        days = self.env['connect.settings'].sudo().get_param('s3_retention_days')
+        now = fields.Datetime.now()
+        for rec in self:
+            rec.recording_expired = s3_utils.is_recording_expired(rec.start_time, days, now)
+
     ############## TRANSCRIPTION METHODS #####################################
 
     def transcribe_recording(self, openai_api_key, summary_prompt):
@@ -76,13 +84,21 @@ class Recording(models.Model):
         temp_file_path = None
         try:
             client = self.env['connect.settings'].get_openai_client()
-            response = requests.get(self.media_url, stream=True)
-            response.raise_for_status()
-            with NamedTemporaryFile(delete=False, suffix=".mp3") as temp_file:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        temp_file.write(chunk)
-                temp_file_path = temp_file.name
+            settings = self.env["connect.settings"].sudo()
+            bucket = settings.get_param("aws_s3_bucket_name")
+            if settings.get_param("s3_recordings_enabled") and s3_utils.is_s3_media_url(self.media_url, bucket):
+                key = s3_utils.parse_s3_key(self.media_url, bucket)
+                with NamedTemporaryFile(delete=False, suffix=".mp3") as temp_file:
+                    settings._get_s3_client().download_fileobj(bucket, key, temp_file)
+                    temp_file_path = temp_file.name
+            else:
+                response = requests.get(self.media_url, stream=True)
+                response.raise_for_status()
+                with NamedTemporaryFile(delete=False, suffix=".mp3") as temp_file:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            temp_file.write(chunk)
+                    temp_file_path = temp_file.name
             file_size = os.path.getsize(temp_file_path)
             if file_size > 26214400:
                 error_msg = 'File exceeds size limit (26MB). Please use the Elevenlabs module for larger files.'
@@ -189,14 +205,27 @@ class Recording(models.Model):
 ##########  END OF TRANSCRIPTION METHODS #########################################################
 
     def _get_recording_widget(self):
-        proxy_recordings = self.env['connect.settings'].sudo().get_param('proxy_recordings')
+        settings = self.env['connect.settings'].sudo()
+        proxy_recordings = settings.get_param('proxy_recordings')
+        s3_enabled = settings.get_param('s3_recordings_enabled')
+        bucket = settings.get_param('aws_s3_bucket_name')
         for rec in self:
             if not rec.media_url:
                 # Fix for Agent recordings.
                 rec.recording_widget = ''
                 continue
+            if rec.recording_expired:
+                rec.recording_widget = '<i>Recording expired</i>'
+                continue
+            is_s3 = s3_enabled and s3_utils.is_s3_media_url(rec.media_url, bucket)
             if proxy_recordings:
                 media_url = '/connect/recording/{}'.format(rec.id)
+            elif is_s3:
+                media_url = settings._get_s3_client().generate_presigned_url(
+                    'get_object',
+                    Params={'Bucket': bucket, 'Key': s3_utils.parse_s3_key(rec.media_url, bucket)},
+                    ExpiresIn=3600,
+                )
             else:
                 media_url = rec.media_url
             rec.recording_widget = '<audio id="sound_file" preload="auto" ' \
@@ -266,6 +295,9 @@ class Recording(models.Model):
             ('called_user', '!=', False)], limit=1).called_user
         if channel:
             call = channel.call
+            if call.disable_recording:
+                debug(self, 'Recording disabled for call %s, skipping' % call.id)
+                return True
             data['channel'] = channel.id
             data['call'] = call.id
             data['partner'] = call.partner.id

--- a/connect/models/s3_utils.py
+++ b/connect/models/s3_utils.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Pure helpers for S3 recording storage.
+
+No Odoo or boto3 imports here on purpose: keep this unit-testable in isolation.
+"""
+import json
+from urllib.parse import urlparse
+from datetime import timedelta
+
+
+# Bucket names are auto-prefixed so they stay inside the IAM policy's allowed
+# ARN (arn:aws:s3:::oduist-connect-*). Keep this in sync with that policy.
+S3_BUCKET_PREFIX = "oduist-connect-"
+
+
+def normalize_bucket_name(name, prefix=S3_BUCKET_PREFIX):
+    """Ensure the bucket name starts with `prefix` (idempotent).
+
+    Blank stays blank. A name already starting with the prefix is returned
+    unchanged; otherwise the prefix is prepended. The user only needs to type a
+    suffix (e.g. "recordings-acme" -> "oduist-connect-recordings-acme").
+    """
+    name = (name or "").strip()
+    if not name:
+        return name
+    return name if name.startswith(prefix) else prefix + name
+
+
+def build_iam_policy(prefix=S3_BUCKET_PREFIX):
+    """Return the least-privilege AWS IAM policy (pretty JSON) for the S3 key.
+
+    Bucket ARNs are derived from `prefix`, so the policy always matches the
+    auto-prefixed bucket names. Attach it to the IAM user whose access key is
+    entered in Connect Settings; it grants only bucket create/configure and
+    object read/write under the prefix, no `iam:*`.
+    """
+    bucket_arn = "arn:aws:s3:::{}*".format(prefix)
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "CreateAndConfigureBucket",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:CreateBucket",
+                    "s3:PutBucketPublicAccessBlock",
+                    "s3:PutEncryptionConfiguration",
+                    "s3:PutLifecycleConfiguration",
+                    "s3:GetBucketLocation",
+                ],
+                "Resource": bucket_arn,
+            },
+            {
+                "Sid": "ReadWriteObjects",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListMultipartUploadParts",
+                    "s3:ListBucketMultipartUploads",
+                ],
+                "Resource": [bucket_arn, bucket_arn + "/*"],
+            },
+        ],
+    }
+    return json.dumps(policy, indent=2)
+
+
+def build_s3_url(bucket, region, prefix):
+    """Return the Twilio-ready https URL for a bucket+prefix (no trailing slash)."""
+    prefix = (prefix or "").strip("/")
+    base = "https://{}.s3.{}.amazonaws.com".format(bucket, region)
+    return "{}/{}".format(base, prefix) if prefix else base
+
+
+def is_s3_media_url(media_url, bucket):
+    """True if media_url points at our S3 bucket (any AWS S3 host style)."""
+    if not media_url or not bucket:
+        return False
+    host = urlparse(media_url).hostname or ""
+    return host.endswith("amazonaws.com") and bucket in media_url
+
+
+def parse_s3_key(media_url, bucket):
+    """Extract the S3 object key from a full https S3 URL.
+
+    Handles virtual-hosted ("bucket.s3...amazonaws.com/key") and
+    path-style ("s3...amazonaws.com/bucket/key").
+    """
+    parsed = urlparse(media_url)
+    host = parsed.hostname or ""
+    path = (parsed.path or "").lstrip("/")
+    if host.startswith("{}.".format(bucket)):
+        return path
+    if path.startswith("{}/".format(bucket)):
+        return path[len(bucket) + 1:]
+    return path
+
+
+def build_lifecycle_config(prefix, days):
+    """S3 lifecycle config that expires objects under prefix after `days`."""
+    prefix = (prefix or "").strip("/")
+    return {
+        "Rules": [{
+            "ID": "connect-recordings-retention",
+            "Filter": {"Prefix": "{}/".format(prefix) if prefix else ""},
+            "Status": "Enabled",
+            "Expiration": {"Days": int(days)},
+        }]
+    }
+
+
+def is_recording_expired(start_time, retention_days, now):
+    """True if a recording's S3 object has passed its lifecycle expiry."""
+    if not retention_days or not start_time:
+        return False
+    return now >= start_time + timedelta(days=int(retention_days))

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -19,9 +19,11 @@ from urllib.parse import urljoin
 
 import httpx
 import openai
+import requests
 from odoo import api, fields, models, release
 from odoo.exceptions import ValidationError
 from twilio.rest import Client
+from . import s3_utils
 from odoo.addons.connect.models.license import ODUIST_MODULES
 ODUIST_MODULES.append('connect')
 
@@ -36,6 +38,7 @@ PROTECTED_FIELDS = [
     "display_region_auth_token",
     "display_twilio_api_secret",
     "display_openai_api_key",
+    "display_aws_secret_access_key",
 ]
 
 TWILIO_EDGES = [
@@ -271,6 +274,61 @@ class Settings(models.Model):
     proxy_recordings = fields.Boolean(
         help="Re-stream recordings using Odoo user auth.", default=True
     )
+    # ---- S3 recording storage (ODU-36) ----
+    s3_recordings_enabled = fields.Boolean(
+        string="Store recordings in S3",
+        help="Turn on to configure and use AWS S3 storage (reveals the settings "
+             "below). Recordings are read from S3 only once a bucket is configured "
+             "and Twilio uploads there; otherwise they keep playing from Twilio.",
+    )
+    aws_access_key_id = fields.Char(string="AWS Access Key ID")
+    aws_secret_access_key = fields.Char(
+        string="AWS Secret Access Key", groups="base.group_erp_manager"
+    )
+    display_aws_secret_access_key = fields.Char()
+    aws_region = fields.Selection(
+        selection=[
+            ("eu-central-1", "EU (Frankfurt)"),
+            ("eu-west-1", "EU (Ireland)"),
+            ("us-east-1", "US East (N. Virginia)"),
+            ("us-west-2", "US West (Oregon)"),
+            ("ap-southeast-1", "Asia Pacific (Singapore)"),
+        ],
+        string="AWS Region", default="eu-central-1", required=True,
+    )
+    aws_s3_bucket_prefix = fields.Char(
+        string="S3 Bucket Prefix", default=lambda self: s3_utils.S3_BUCKET_PREFIX,
+        help="Bucket names are forced to start with this prefix, and the IAM policy "
+             "above is scoped to it. Default 'oduist-connect-'. Set your own to match "
+             "an existing IAM naming convention (leave empty to use the default).",
+    )
+    aws_s3_bucket = fields.Char(
+        string="S3 Bucket Name",
+        help="The bucket name (or just a suffix). The prefix above is combined with "
+             "it dynamically to form the full bucket name shown below.",
+    )
+    aws_s3_bucket_name = fields.Char(
+        string="Full Bucket Name", compute="_compute_aws_s3_bucket_name", readonly=True,
+        help="Actual bucket = prefix + name. Used for provisioning, the S3 URL and "
+             "playback.",
+    )
+    aws_s3_prefix = fields.Char(string="S3 Folder (prefix)", default="recordings")
+    s3_retention_days = fields.Integer(
+        string="Retention (days)", default=0,
+        help="0 = keep forever. >0 sets an S3 lifecycle rule that deletes the audio "
+             "file after N days (the recording row and transcript are kept).",
+    )
+    aws_s3_url = fields.Char(
+        string="S3 URL (paste into Twilio)", compute="_compute_aws_s3_url", readonly=True,
+    )
+    aws_iam_policy = fields.Text(
+        string="AWS IAM Policy", compute="_compute_aws_iam_policy", readonly=True,
+        help="Least-privilege policy to attach to the AWS IAM user whose access "
+             "key you enter below. Copy it into IAM → Users → Add inline policy.",
+    )
+    twilio_aws_credential_sid = fields.Char(
+        string="Twilio AWS Credential SID", readonly=True,
+    )
     transcript_calls = fields.Boolean()
     transcript_provider = fields.Selection(
         selection=[("openai", "Open AI")], default="openai", required=True
@@ -287,6 +345,11 @@ class Settings(models.Model):
         default=False,
         string="Fetch Call Prices",
         help="Enable fetching call prices from Twilio API after call completion. May add delay to call processing.",
+    )
+    enable_auto_reload_view = fields.Boolean(
+        string="Auto Reload Views",
+        help="Automatically refresh open Connect views (e.g. call list, recordings) in real time "
+        "when records change, pushed over the bus. Disable to reduce browser and bus traffic.",
     )
     ############################################################
     api_url = fields.Char("API URL", compute="_get_instance_data")
@@ -368,6 +431,8 @@ class Settings(models.Model):
 
     @api.model
     def connect_reload_view(self, model):
+        if not self.get_param('enable_auto_reload_view'):
+            return
         if release.version_info[0] < 15:
             msg = {
                 "action": "reload_view",
@@ -384,6 +449,178 @@ class Settings(models.Model):
     def _get_name(self):
         for rec in self:
             rec.name = "Connect Settings"
+
+    # ---- S3 recording storage (ODU-36) ----
+    @api.depends("aws_s3_bucket_name", "aws_region", "aws_s3_prefix")
+    def _compute_aws_s3_url(self):
+        for rec in self:
+            if rec.aws_s3_bucket_name and rec.aws_region:
+                rec.aws_s3_url = s3_utils.build_s3_url(
+                    rec.aws_s3_bucket_name, rec.aws_region, rec.aws_s3_prefix
+                )
+            else:
+                rec.aws_s3_url = False
+
+    @api.depends("aws_s3_bucket", "aws_s3_bucket_prefix")
+    def _compute_aws_s3_bucket_name(self):
+        """Full bucket = prefix + name, derived dynamically (input is never mutated)."""
+        for rec in self:
+            rec.aws_s3_bucket_name = s3_utils.normalize_bucket_name(
+                rec.aws_s3_bucket, rec._effective_s3_prefix()
+            )
+
+    def _effective_s3_prefix(self):
+        """Configured bucket prefix, falling back to the module default."""
+        self.ensure_one()
+        return self.aws_s3_bucket_prefix or s3_utils.S3_BUCKET_PREFIX
+
+    @api.depends("aws_s3_bucket_prefix")
+    def _compute_aws_iam_policy(self):
+        for rec in self:
+            rec.aws_iam_policy = s3_utils.build_iam_policy(rec._effective_s3_prefix())
+
+    def _get_s3_client(self):
+        """boto3 S3 client built from the singleton settings (sudo to read secret)."""
+        import boto3
+        rec = self.env["connect.settings"].sudo().search([], limit=1)
+        return boto3.client(
+            "s3",
+            aws_access_key_id=rec.aws_access_key_id,
+            aws_secret_access_key=rec.aws_secret_access_key,
+            region_name=rec.aws_region,
+        )
+
+    def action_provision_s3_bucket(self):
+        from botocore.exceptions import ClientError
+        self.ensure_one()
+        if not (self.aws_s3_bucket and self.aws_region):
+            raise ValidationError("Set S3 bucket name and region first.")
+        s3 = self._get_s3_client()
+        prefix = self._effective_s3_prefix()
+        bucket = self.aws_s3_bucket_name
+        try:
+            if self.aws_region == "us-east-1":
+                s3.create_bucket(Bucket=bucket)
+            else:
+                s3.create_bucket(
+                    Bucket=bucket,
+                    CreateBucketConfiguration={"LocationConstraint": self.aws_region},
+                )
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code == "AccessDenied":
+                raise ValidationError(
+                    "AWS denied s3:CreateBucket for '%s'. The '%s' prefix is added "
+                    "automatically, so this usually means the IAM policy is not "
+                    "attached to this key, or its Resource ARN uses a different "
+                    "prefix. Allow s3:CreateBucket on 'arn:aws:s3:::%s*'.\n\n%s"
+                    % (bucket, prefix, prefix, e)
+                )
+            if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                raise ValidationError("S3 create_bucket failed: %s" % e)
+        s3.put_public_access_block(
+            Bucket=bucket,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": True, "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True, "RestrictPublicBuckets": True,
+            },
+        )
+        s3.put_bucket_encryption(
+            Bucket=bucket,
+            ServerSideEncryptionConfiguration={
+                "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+            },
+        )
+        if self.s3_retention_days and self.s3_retention_days > 0:
+            s3.put_bucket_lifecycle_configuration(
+                Bucket=bucket,
+                LifecycleConfiguration=s3_utils.build_lifecycle_config(
+                    self.aws_s3_prefix, self.s3_retention_days
+                ),
+            )
+        self.connect_notify("S3 bucket '%s' provisioned." % bucket, notify_uid=self.env.uid)
+        return True
+
+    def action_create_twilio_aws_credential(self):
+        self.ensure_one()
+        settings = self.env["connect.settings"].sudo()
+        access_key = self.aws_access_key_id
+        secret = settings.get_param("aws_secret_access_key")
+        if not (access_key and secret):
+            raise ValidationError("Set AWS access key and secret first.")
+        sid = settings.get_param("account_sid")
+        token = settings.get_param("auth_token")
+        friendly = "connect-s3-recordings"
+        base = "https://accounts.twilio.com/v1/Credentials/AWS"
+        try:
+            existing = requests.get(base, auth=(sid, token), timeout=30)
+            existing.raise_for_status()
+            for cred in existing.json().get("credentials", []):
+                if cred.get("friendly_name") == friendly:
+                    self.twilio_aws_credential_sid = cred["sid"]
+                    self.connect_notify(
+                        "Twilio AWS credential '%s' already exists: %s"
+                        % (friendly, cred["sid"]),
+                        notify_uid=self.env.uid,
+                    )
+                    return True
+            resp = requests.post(
+                base, auth=(sid, token), timeout=30,
+                data={
+                    "Credentials": "%s:%s" % (access_key, secret),
+                    "FriendlyName": friendly,
+                },
+            )
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            raise ValidationError("Twilio AWS credential request failed: %s" % e)
+        self.twilio_aws_credential_sid = resp.json()["sid"]
+        self.connect_notify(
+            "Twilio AWS credential created: %s" % self.twilio_aws_credential_sid,
+            notify_uid=self.env.uid,
+        )
+        return True
+
+    def action_recreate_twilio_aws_credential(self):
+        """Delete the existing connect-s3-recordings credential and create a fresh
+        one with the current AWS keys (Twilio can't update a credential's key).
+        The new SID must be re-selected in the Twilio Console."""
+        self.ensure_one()
+        settings = self.env["connect.settings"].sudo()
+        access_key = self.aws_access_key_id
+        secret = settings.get_param("aws_secret_access_key")
+        if not (access_key and secret):
+            raise ValidationError("Set AWS access key and secret first.")
+        sid = settings.get_param("account_sid")
+        token = settings.get_param("auth_token")
+        friendly = "connect-s3-recordings"
+        base = "https://accounts.twilio.com/v1/Credentials/AWS"
+        try:
+            existing = requests.get(base, auth=(sid, token), timeout=30)
+            existing.raise_for_status()
+            for cred in existing.json().get("credentials", []):
+                if cred.get("friendly_name") == friendly:
+                    deleted = requests.delete(
+                        "%s/%s" % (base, cred["sid"]), auth=(sid, token), timeout=30
+                    )
+                    deleted.raise_for_status()
+            resp = requests.post(
+                base, auth=(sid, token), timeout=30,
+                data={
+                    "Credentials": "%s:%s" % (access_key, secret),
+                    "FriendlyName": friendly,
+                },
+            )
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            raise ValidationError("Twilio AWS credential request failed: %s" % e)
+        self.twilio_aws_credential_sid = resp.json()["sid"]
+        self.connect_notify(
+            "Twilio AWS credential recreated: %s. Re-select it in Twilio Console "
+            "→ Voice → Recordings → Settings." % self.twilio_aws_credential_sid,
+            notify_uid=self.env.uid, sticky=True,
+        )
+        return True
 
     def open_settings_form(self):
         rec = self.search([])

--- a/connect/security/groups.xml
+++ b/connect/security/groups.xml
@@ -24,4 +24,9 @@
         <field name="users" eval="[(4, ref('connect.user_connect_webhook'))]"/>
     </record>
 
+    <record model="res.groups" id="group_connect_do_not_record">
+        <field name="name">Do not record</field>
+        <field name="category_id" ref="connect.module_connect_category"/>
+    </record>
+
 </odoo>

--- a/connect/static/src/services/active_calls/active_calls_popup.js
+++ b/connect/static/src/services/active_calls/active_calls_popup.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 import {useService} from "@web/core/utils/hooks"
 
-import {Component, useState} from "@odoo/owl"
+import {Component, useState, onWillStart} from "@odoo/owl"
 
 export class ConnectActiveCallsPopup extends Component {
     static template = 'connect.active_calls_popup'
@@ -22,6 +22,10 @@ export class ConnectActiveCallsPopup extends Component {
         super.setup()
         this.orm = useService('orm')
         this.action = useService('action')
+        this.canDisableRecording = false
+        onWillStart(async () => {
+            this.canDisableRecording = await this.orm.call("connect.call", "can_disable_recording", [])
+        })
         this.props.bus.addEventListener('connect_active_calls_toggle_display', (ev) => this.toggleDisplay(ev))
     }
 
@@ -88,6 +92,13 @@ export class ConnectActiveCallsPopup extends Component {
                 views: [[false, 'form']],
             })
         }
+    }
+
+    async _toggleDisableRecording(ev, call) {
+        ev.stopPropagation()
+        const value = !call.disable_recording
+        const result = await this.orm.call("connect.call", "set_disable_recording", [call.id, value])
+        call.disable_recording = result
     }
 
     _onMouseOver(ev) {

--- a/connect/static/src/services/active_calls/active_calls_popup.xml
+++ b/connect/static/src/services/active_calls/active_calls_popup.xml
@@ -15,6 +15,7 @@
                                 <th>Called User</th>
                                 <th class="partner-th">Partner</th>
                                 <th>Direction</th>
+                                <th t-if="canDisableRecording">Rec</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -29,6 +30,14 @@
                                     </td>
                                     <td t-attf-title="{{call.direction ? call.direction : ''}}">
                                         <t t-out="call.direction"/>
+                                    </td>
+                                    <td t-if="canDisableRecording" class="text-center" style="cursor: pointer;"
+                                        t-on-click="(ev) => this._toggleDisableRecording(ev, call)">
+                                        <div t-attf-class="{{ call.disable_recording ? 'text-muted' : 'text-danger' }}" style="line-height: 1;"
+                                             t-attf-title="{{ call.disable_recording ? 'Recording disabled — click to enable' : 'Recording — click to disable' }}">
+                                            <i class="fa fa-circle"/>
+                                            <div style="font-size: 9px; font-weight: bold;">REC</div>
+                                        </div>
                                     </td>
                                 </tr>
                             </t>

--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import test_s3_utils
+from . import test_s3_settings

--- a/connect/tests/test_s3_settings.py
+++ b/connect/tests/test_s3_settings.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestS3Settings(TransactionCase):
+    def test_aws_s3_url_compute(self):
+        s = self.env["connect.settings"].create({
+            "aws_s3_bucket": "my-bucket",
+            "aws_region": "eu-central-1",
+            "aws_s3_prefix": "recordings",
+        })
+        self.assertEqual(
+            s.aws_s3_url,
+            "https://my-bucket.s3.eu-central-1.amazonaws.com/recordings",
+        )
+
+    def test_aws_s3_url_empty_without_bucket(self):
+        s = self.env["connect.settings"].create({"aws_region": "us-east-1"})
+        self.assertFalse(s.aws_s3_url)
+
+    def test_recording_expired_flag(self):
+        self.env["connect.settings"].search([], limit=1).write({"s3_retention_days": 30})
+        recording = self.env["connect.recording"].with_context(skip_transcription=True)
+        old = recording.create({
+            "sid": "REtest_old", "call_sid": "CAtest",
+            "start_time": datetime.now() - timedelta(days=40),
+        })
+        fresh = recording.create({
+            "sid": "REtest_new", "call_sid": "CAtest",
+            "start_time": datetime.now() - timedelta(days=1),
+        })
+        self.assertTrue(old.recording_expired)
+        self.assertFalse(fresh.recording_expired)

--- a/connect/tests/test_s3_utils.py
+++ b/connect/tests/test_s3_utils.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+import unittest
+from datetime import datetime
+from odoo.addons.connect.models import s3_utils
+
+
+class TestS3Utils(unittest.TestCase):
+    # ---- build_s3_url ----
+    def test_build_s3_url_with_prefix(self):
+        url = s3_utils.build_s3_url("my-bucket", "eu-central-1", "recordings")
+        self.assertEqual(url, "https://my-bucket.s3.eu-central-1.amazonaws.com/recordings")
+
+    def test_build_s3_url_strips_slashes(self):
+        url = s3_utils.build_s3_url("my-bucket", "eu-central-1", "/recordings/")
+        self.assertEqual(url, "https://my-bucket.s3.eu-central-1.amazonaws.com/recordings")
+
+    def test_build_s3_url_no_prefix(self):
+        url = s3_utils.build_s3_url("my-bucket", "us-east-1", "")
+        self.assertEqual(url, "https://my-bucket.s3.us-east-1.amazonaws.com")
+
+    # ---- is_s3_media_url ----
+    def test_is_s3_media_url_true_virtual_hosted(self):
+        url = "https://my-bucket.s3.eu-central-1.amazonaws.com/recordings/AC1/RE1"
+        self.assertTrue(s3_utils.is_s3_media_url(url, "my-bucket"))
+
+    def test_is_s3_media_url_false_for_twilio(self):
+        url = "https://api.twilio.com/2010-04-01/Accounts/AC1/Recordings/RE1"
+        self.assertFalse(s3_utils.is_s3_media_url(url, "my-bucket"))
+
+    def test_is_s3_media_url_false_when_empty(self):
+        self.assertFalse(s3_utils.is_s3_media_url("", "my-bucket"))
+
+    # ---- parse_s3_key ----
+    def test_parse_s3_key_virtual_hosted(self):
+        url = "https://my-bucket.s3.eu-central-1.amazonaws.com/recordings/AC1/RE1.mp3"
+        self.assertEqual(s3_utils.parse_s3_key(url, "my-bucket"), "recordings/AC1/RE1.mp3")
+
+    def test_parse_s3_key_path_style(self):
+        url = "https://s3.eu-central-1.amazonaws.com/my-bucket/recordings/RE1.mp3"
+        self.assertEqual(s3_utils.parse_s3_key(url, "my-bucket"), "recordings/RE1.mp3")
+
+    # ---- normalize_bucket_name ----
+    def test_normalize_bucket_name_adds_prefix(self):
+        self.assertEqual(
+            s3_utils.normalize_bucket_name("recordings-acme"),
+            "oduist-connect-recordings-acme",
+        )
+
+    def test_normalize_bucket_name_keeps_existing_prefix(self):
+        self.assertEqual(
+            s3_utils.normalize_bucket_name("oduist-connect-test"),
+            "oduist-connect-test",
+        )
+
+    def test_normalize_bucket_name_is_idempotent(self):
+        once = s3_utils.normalize_bucket_name("test")
+        self.assertEqual(s3_utils.normalize_bucket_name(once), once)
+
+    def test_normalize_bucket_name_trims_whitespace(self):
+        self.assertEqual(
+            s3_utils.normalize_bucket_name("  test  "),
+            "oduist-connect-test",
+        )
+
+    def test_normalize_bucket_name_empty_stays_empty(self):
+        self.assertEqual(s3_utils.normalize_bucket_name(""), "")
+        self.assertEqual(s3_utils.normalize_bucket_name(None), "")
+        self.assertEqual(s3_utils.normalize_bucket_name("   "), "")
+
+    def test_normalize_bucket_name_custom_prefix(self):
+        self.assertEqual(
+            s3_utils.normalize_bucket_name("acme", prefix="my-prefix-"),
+            "my-prefix-acme",
+        )
+
+    # ---- build_iam_policy ----
+    def test_build_iam_policy_is_valid_json(self):
+        import json
+        doc = json.loads(s3_utils.build_iam_policy())
+        self.assertEqual(doc["Version"], "2012-10-17")
+        sids = [s["Sid"] for s in doc["Statement"]]
+        self.assertEqual(sids, ["CreateAndConfigureBucket", "ReadWriteObjects"])
+
+    def test_build_iam_policy_default_prefix_arns(self):
+        import json
+        doc = json.loads(s3_utils.build_iam_policy())
+        create = next(s for s in doc["Statement"] if s["Sid"] == "CreateAndConfigureBucket")
+        self.assertIn("s3:CreateBucket", create["Action"])
+        self.assertEqual(create["Resource"], "arn:aws:s3:::oduist-connect-*")
+
+    def test_build_iam_policy_object_arns_use_prefix(self):
+        import json
+        doc = json.loads(s3_utils.build_iam_policy(prefix="my-prefix-"))
+        rw = next(s for s in doc["Statement"] if s["Sid"] == "ReadWriteObjects")
+        self.assertEqual(
+            rw["Resource"],
+            ["arn:aws:s3:::my-prefix-*", "arn:aws:s3:::my-prefix-*/*"],
+        )
+
+    # ---- build_lifecycle_config ----
+    def test_build_lifecycle_config(self):
+        cfg = s3_utils.build_lifecycle_config("recordings", 30)
+        rule = cfg["Rules"][0]
+        self.assertEqual(rule["Status"], "Enabled")
+        self.assertEqual(rule["Expiration"], {"Days": 30})
+        self.assertEqual(rule["Filter"], {"Prefix": "recordings/"})
+        self.assertEqual(rule["ID"], "connect-recordings-retention")
+
+    # ---- is_recording_expired ----
+    def test_recording_not_expired_when_retention_zero(self):
+        self.assertFalse(s3_utils.is_recording_expired(datetime(2020, 1, 1), 0, datetime(2030, 1, 1)))
+
+    def test_recording_not_expired_when_no_start(self):
+        self.assertFalse(s3_utils.is_recording_expired(None, 30, datetime(2030, 1, 1)))
+
+    def test_recording_expired_after_window(self):
+        start = datetime(2026, 1, 1)
+        self.assertTrue(s3_utils.is_recording_expired(start, 30, datetime(2026, 3, 1)))
+
+    def test_recording_not_expired_within_window(self):
+        start = datetime(2026, 1, 1)
+        self.assertFalse(s3_utils.is_recording_expired(start, 30, datetime(2026, 1, 10)))

--- a/connect/views/call.xml
+++ b/connect/views/call.xml
@@ -45,6 +45,7 @@
                 <field name="status" optional="show"/>
                 <field name="price" optional="hide" groups="connect.group_connect_admin" sum="Total Cost"/>
                 <field name="price_unit" optional="hide" groups="connect.group_connect_admin"/>
+                <field name="has_activity" optional="show"/>
                 <field name="recording_icon" widget="html" optional="show"/>
                 <field name="voicemail_icon" optional="show"/>
             </list>

--- a/connect/views/settings.xml
+++ b/connect/views/settings.xml
@@ -27,6 +27,7 @@
                       <field name="api_url" string="Odoo URL"/>
                       <button class="btn btn-primary" colspan="2" name="action_open_system_parameters" type="object" string="Change Odoo URL"/>
                       <field name="api_fallback_url" string="Fallback URL"/>
+                      <field name="enable_auto_reload_view"/>
                       <field name="debug_mode"/>
                     </group>
                     <group string="Balance">
@@ -70,6 +71,56 @@
                     </group>
                     <group>
                       <button colspan="2" name="reformat_numbers_button" string="FORMAT NUMBERS" type="object"/>
+                    </group>
+                  </group>
+                </page>
+                <page name="s3_storage" string="S3 Storage">
+                  <group>
+                    <group string="AWS S3" name="aws_s3">
+                      <field name="s3_recordings_enabled"/>
+                      <separator string="1. Choose a bucket prefix (the IAM policy below is scoped to it)" colspan="2" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_s3_bucket_prefix" invisible="not s3_recordings_enabled"/>
+                      <separator string="2. Create an AWS IAM user with this least-privilege policy" colspan="2" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_iam_policy" nolabel="1" colspan="2" widget="ace" options="{'mode': 'javascript'}" readonly="1" invisible="not s3_recordings_enabled"/>
+                      <div colspan="2" class="text-muted" invisible="not s3_recordings_enabled">
+                        <p>Create the IAM user (one time):</p>
+                        <ol>
+                          <li>AWS Console → <strong>IAM → Users → Create user</strong> (e.g. <code>connect-s3</code>).</li>
+                          <li>On <strong>Set permissions</strong> pick <strong>Attach policies directly</strong> → <strong>Create policy</strong> → <strong>JSON</strong> tab → paste the policy above → name it (e.g. <code>connect-s3-recordings</code>) → create, then attach it to the user.</li>
+                          <li>Open the user → <strong>Security credentials</strong> → <strong>Create access key</strong> → <em>Application running outside AWS</em> → copy the <strong>Access Key ID</strong> and <strong>Secret access key</strong>.</li>
+                          <li>Paste them below.</li>
+                        </ol>
+                      </div>
+                      <separator string="3. Paste the IAM user's access key" colspan="2" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_access_key_id" invisible="not s3_recordings_enabled"/>
+                      <field name="display_aws_secret_access_key" string="AWS Secret Access Key" password="1" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_region" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_s3_bucket" placeholder="recordings-acme" invisible="not s3_recordings_enabled"
+                             help="Enter a name (or just a suffix). The prefix above is combined with it to form the full bucket name shown below."/>
+                      <field name="aws_s3_bucket_name" readonly="1" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_s3_prefix" invisible="not s3_recordings_enabled"/>
+                      <field name="s3_retention_days" invisible="not s3_recordings_enabled"/>
+                      <button colspan="2" name="action_provision_s3_bucket" type="object" string="CREATE / CONFIGURE S3 BUCKET" class="btn btn-primary" invisible="not s3_recordings_enabled"/>
+                      <div colspan="2" invisible="not s3_recordings_enabled">
+                        <button name="action_create_twilio_aws_credential" type="object" string="CREATE TWILIO AWS CREDENTIAL" class="btn btn-secondary me-2"/>
+                        <button name="action_recreate_twilio_aws_credential" type="object" string="RECREATE TWILIO CREDENTIAL" class="btn btn-secondary"
+                                confirm="Delete the existing 'connect-s3-recordings' Twilio credential and create a new one with the current AWS keys? The new SID must be re-selected in the Twilio Console."/>
+                      </div>
+                      <field name="twilio_aws_credential_sid" readonly="1" invisible="not s3_recordings_enabled"/>
+                      <field name="aws_s3_url" readonly="1" invisible="not s3_recordings_enabled"/>
+                    </group>
+                    <group string="Twilio Console (final step)" name="s3_instructions" invisible="not s3_recordings_enabled">
+                      <div colspan="2" class="text-muted">
+                        <p><strong>Voice external storage has no API — do this once in the Twilio Console:</strong></p>
+                        <ol>
+                          <li>Twilio Console → Voice → Recordings → Settings.</li>
+                          <li>Enable external S3 storage.</li>
+                          <li>Pick AWS credential <em>connect-s3-recordings</em> (SID shown on the left).</li>
+                          <li>Paste the <strong>S3 URL</strong> shown on the left.</li>
+                          <li>Save. New recordings now go to your bucket.</li>
+                          <li>Then tick <em>Store recordings in S3</em> here.</li>
+                        </ol>
+                      </div>
                     </group>
                   </group>
                 </page>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ phonenumbers
 twilio
 elevenlabs
 openai
+boto3
 
 # For Odoo 18.0 official docker image:
 # pip3 install --user  --force-reinstall --break-system-package typing_extensions openai


### PR DESCRIPTION
Backport of 19.0 commits `17445e5` (19.0 connect calls improvements, #119) and `9c63710` (fix ci) to **18.0**.

### Included
- **S3 recording storage** — `s3_utils.py`, settings fields/actions, presigned playback, transcription & controller S3 branches, IAM policy + Twilio credential helpers, retention/lifecycle.
- **"Do not record" group** + per-call `disable_recording` toggle in the active-calls widget (gated on group membership + `record_calls`).
- **has_activity (A)** column on the call list, synced on activity create/done/unlink.
- **Auto Reload Views** setting gating `connect_reload_view`.
- **Live in-progress call status** (`_update_live_status`) on answer.
- `boto3` added to `requirements.txt`, manifest external deps, and CI `addons.yml`.

### Version adaptations for 18.0
- "Do not record" group uses `category_id` (no 19.0-only `res.groups.privilege`).
- View syntax matched to 18.0 (list/tree tag; `invisible=`/`attrs=` as appropriate).
- ORM API matched to 18.0 (`invalidate_recordset`/`invalidate_cache`).

### Verification
`py_compile` + XML well-formedness on all changed files. `connect` installs cleanly from scratch on a fresh `odoo:18.0` Oduflow environment (template=none, exit code 0).