### PR TITLE
Remove Auto Reload Views feature (16.0 backport)

### DIFF
--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -912,8 +912,6 @@ class Call(models.Model):
             logger.info(f"Call {channel.call.id}: Finalization deferred - {reason}")
             # Call is still active: keep its status live (ringing -> in-progress).
             channel.call._update_live_status()
-        # Reload call view
-        self.env['connect.settings'].connect_reload_view('connect.call')
         if params.get('ErrorCode') and params.get('ErrorCode') not in IGNORE_ERROR_CODES:
             channel.call.update({
                 'has_error': True,
@@ -1266,18 +1264,12 @@ class Call(models.Model):
 
     @api.constrains('summary')
     def register_partner_call_summary(self):
-        reload_view = False
         register_summary = self.env['connect.settings'].sudo().get_param('register_summary')
         if not register_summary:
             return
         for rec in self:
             if rec.partner and rec.summary:
                 self.register_summary_to_rec(rec.partner, rec.summary)
-                reload_view = True
-        # Reload changed view.
-        if reload_view:
-            # Reload the view of res.partner
-            self.env['connect.settings'].connect_reload_view('res.partner')
 
     def create_partner_button(self):
         self.ensure_one()

--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -348,7 +348,6 @@ class ConnectMessage(models.Model):
                         chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
                         chatter.connect_message = message
                         # Let Odoo generate notifications for followers automatically (no manual mail.notification)
-                        self.env['connect.settings'].connect_reload_view(target_msg.res_model)
             else:
                 # Update message status
                 logger.info("Received Update Twilio SMS webhook data:\n%s", params)
@@ -424,7 +423,6 @@ class ConnectMessage(models.Model):
                     'notification_status': 'ready',
                 }]
                 self.env['mail.notification'].sudo().create(mail_notification_values)
-                self.env['connect.settings'].connect_reload_view(res_model)
 
     def client_send(self, recipient, sender, body):
         api_url = self.env['connect.settings'].get_param('api_url')
@@ -528,6 +526,5 @@ class ConnectMessage(models.Model):
                     'is_read': True,
                     'notification_status': 'ready',
                 }])
-                self.env['connect.settings'].connect_reload_view(res_model)
         except Exception as e:
             logger.warning('Failed to post SMS chatter message on %s,%s: %s', res_model, res_id, e)

--- a/connect/models/outgoing_callerid.py
+++ b/connect/models/outgoing_callerid.py
@@ -106,7 +106,6 @@ class OutgoingCallerID(models.Model):
             number.write({'status': 'validated', 'sid': params['OutgoingCallerIdSid']})
         else:
             number.status = 'validation failed'
-        self.env['connect.settings'].connect_reload_view('connect.outgoing_callerid')
         return True
 
     def validate(self):

--- a/connect/models/recording.py
+++ b/connect/models/recording.py
@@ -193,10 +193,6 @@ class Recording(models.Model):
         # Update call summary.
         if self.call:
             self.call.summary = data.get('summary')
-            # Reload calls view when transcription has come.
-            self.env['connect.settings'].connect_reload_view('connect.call')
-        # Reload views when transcription has come.
-        self.env['connect.settings'].connect_reload_view('connect.recording')
         # Notify user
         if data.get('notify_uid'):
             self.env['connect.settings'].connect_notify(

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -346,11 +346,6 @@ class Settings(models.Model):
         string="Fetch Call Prices",
         help="Enable fetching call prices from Twilio API after call completion. May add delay to call processing.",
     )
-    enable_auto_reload_view = fields.Boolean(
-        string="Auto Reload Views",
-        help="Automatically refresh open Connect views (e.g. call list, recordings) in real time "
-        "when records change, pushed over the bus. Disable to reduce browser and bus traffic.",
-    )
     ############################################################
     api_url = fields.Char("API URL", compute="_get_instance_data")
     api_fallback_url = fields.Char("API Fallback URL")
@@ -428,22 +423,6 @@ class Settings(models.Model):
             )
 
         return True
-
-    @api.model
-    def connect_reload_view(self, model):
-        if not self.get_param('enable_auto_reload_view'):
-            return
-        if release.version_info[0] < 15:
-            msg = {
-                "action": "reload_view",
-                "model": model,
-            }
-            self.env["bus.bus"].sendone("connect_actions", json.dumps(msg))
-        else:
-            msg = {"model": model}
-            self.env["bus.bus"]._sendone("connect_actions", "reload_view", msg)
-
-
 
     @api.model
     def _get_name(self):

--- a/connect/models/whatsapp_sender.py
+++ b/connect/models/whatsapp_sender.py
@@ -351,7 +351,6 @@ class ConnectWhatsappSender(models.Model):
                     'is_read': True,
                     'notification_status': 'ready',
                 }])
-                self.env['connect.settings'].connect_reload_view(res_model)
         except Exception as e:
             logger.warning('Failed to post WhatsApp chatter message on %s,%s: %s', res_model, res_id, e)
 

--- a/connect/static/src/services/actions/actions.js
+++ b/connect/static/src/services/actions/actions.js
@@ -31,8 +31,6 @@ export const pbxActionService = {
                     this.connect_handle_notify(payload);
                 else if (type === 'open_record')
                     this.connect_handle_open_record(payload)
-                else if (type === 'reload_view')
-                    this.connect_handle_reload_view(payload)
             } catch (e) {
                 console.log(e)
             }
@@ -51,14 +49,6 @@ export const pbxActionService = {
                 'views': [[message.view_id, 'form']],
                 'view_mode': 'tree,form',
             })
-        }
-    },
-
-    connect_handle_reload_view: function (message) {
-        if (!this.action || !this.action.currentController) return
-        const action = this.action.currentController.action
-        if (action.res_model === message.model) {
-            this.bus.trigger("ROUTE_CHANGE")
         }
     },
 

--- a/connect/views/settings.xml
+++ b/connect/views/settings.xml
@@ -27,7 +27,6 @@
                       <field name="api_url" string="Odoo URL"/>
                       <button class="btn btn-primary" colspan="2" name="action_open_system_parameters" type="object" string="Change Odoo URL"/>
                       <field name="api_fallback_url" string="Fallback URL"/>
-                      <field name="enable_auto_reload_view"/>
                       <field name="debug_mode"/>
                     </group>
                     <group string="Balance">

--- a/connect_crm/models/call.py
+++ b/connect_crm/models/call.py
@@ -207,15 +207,9 @@ class CrmCall(models.Model):
     def register_crm_lead_call_summary(self):
         if not self.env['oduist.license'].check_license('connect_crm', silent=True):
             return False
-        reload_view = False
         register_summary = self.env['connect.settings'].sudo().get_param('register_summary')
         if not register_summary:
             return
         for rec in self:
             if rec.lead and rec.summary:
                 self.register_summary_to_rec(rec.lead, rec.summary)
-                reload_view = True
-        # Reload changed view.
-        if reload_view:
-            # Reload the view of res.partner
-            self.env['connect.settings'].connect_reload_view('crm.lead')


### PR DESCRIPTION
Backport of the Auto Reload Views removal to 16.0.

### Why
The `enable_auto_reload_view` setting pushed a `reload_view` bus message whenever a call list, transcription or summary changed, forcing open Odoo views to reload — disrupting users mid-edit (typed text/notes lost). The feature is removed entirely.

### Changes
- Drop the `enable_auto_reload_view` setting field + settings-form entry.
- Drop `connect.settings.connect_reload_view()` bus sender.
- Drop all `connect_reload_view()` call sites (calls, recordings/transcriptions, SMS & WhatsApp chatter, caller-id validation, CRM lead summary).
- In `actions.js`, drop only the `reload_view` dispatcher branch and its `connect_handle_reload_view` handler. The unrelated `connect_notify` and `open_record` handlers and the bus channels are kept intact.

### Verification (Oduflow, fresh env, no template, odoo:16.0)
- `connect` + `connect_crm` install cleanly.
- Shell checks: field gone, `connect_reload_view` gone, `connect_notify` present, settings view does not reference the removed field.
- Tests: only the pre-existing unrelated `TestS3Settings.test_aws_s3_url_compute` fails; no new failures.