### PR TITLE
Optional Twilio-compatible voice API settings (~135 lines)

### DIFF
--- a/connect/models/domain.py
+++ b/connect/models/domain.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 from odoo import fields, models, api, release
 from odoo.exceptions import ValidationError
 from twilio.twiml.voice_response import Client, Dial, VoiceResponse
-from .settings import format_connect_response, debug, TWILIO_EDGES
+from .settings import format_connect_response, debug, TWILIO_EDGES, DEFAULT_SIP_DOMAIN_SUFFIX
 from .twiml import pretty_xml
 
 
@@ -48,13 +48,19 @@ class Domain(models.Model):
     ]
 
     def _get_domain_name(self):
-        edge = self.env['connect.settings'].sudo().get_param('twilio_edge')
+        settings = self.env['connect.settings']
         edges = [v[0] for v in TWILIO_EDGES if v[0] != 'roaming']
+        suffix = settings.normalized_sip_domain_suffix()
         for rec in self:
             if rec.subdomain:
-                rec.domain_name = rec.subdomain + ".sip.twilio.com"
-                rec.edge_domains = '\n'.join(['{}.sip.{}.twilio.com'.format(
-                    rec.subdomain, edge) for edge in edges])
+                rec.domain_name = settings.format_sip_domain_name(rec.subdomain)
+                if suffix == DEFAULT_SIP_DOMAIN_SUFFIX:
+                    rec.edge_domains = '\n'.join([
+                        settings.format_sip_edge_domain(rec.subdomain, edge)
+                        for edge in edges
+                    ])
+                else:
+                    rec.edge_domains = rec.domain_name
             else:
                 rec.domain_name = ''
                 rec.edge_domains = ''
@@ -521,10 +527,10 @@ class Domain(models.Model):
         self.env["connect.call"].on_call_status(request)
         to_val = request.get("To") or ''
         # Extract number for SIP or WhatsApp channels
-        found = re.search(r"^sip:(.+)@(.+)\.sip\.((.+)\.)?twilio\.com", to_val)
+        found_num = self.env['connect.settings'].parse_sip_to_user(to_val)
         is_whatsapp = False
-        if found:
-            found_num = found.group(1)
+        if found_num is not None:
+            pass
         elif isinstance(to_val, str) and to_val.startswith('whatsapp:'):
             found_num = to_val.split(':', 1)[1]
             is_whatsapp = True

--- a/connect/models/number.py
+++ b/connect/models/number.py
@@ -84,7 +84,7 @@ class Number(models.Model):
                 status_callback=self.voice_status_url
             )
             region = self.env['connect.settings'].sudo().get_param('twilio_region')
-            if region and region != 'us1':
+            if region and region != 'us1' and not self.env['connect.settings'].uses_compatible_rest_api():
                 us_client = self.env['connect.settings'].get_client(region=False)
                 us_client.incoming_phone_numbers(self.sid).update(
                     sms_url=self.message_url,

--- a/connect/models/outgoing_callerid.py
+++ b/connect/models/outgoing_callerid.py
@@ -110,7 +110,8 @@ class OutgoingCallerID(models.Model):
 
     def validate(self):
         self.ensure_one()
-        if self.env['connect.settings'].sudo().get_param('twilio_region') != 'us1':
+        if (self.env['connect.settings'].sudo().get_param('twilio_region') != 'us1'
+                and not self.env['connect.settings'].uses_compatible_rest_api()):
             raise ValidationError('Outgoing CallerIds are supported in US1 region only!')
         if self.sid:
             raise ValidationError('Outgoing callerid is already validated!')

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -15,7 +15,7 @@ import os
 import random
 import re
 import string
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpx
 import openai
@@ -23,6 +23,7 @@ import requests
 from odoo import api, fields, models, release
 from odoo.exceptions import ValidationError
 from twilio.rest import Client
+from twilio.http.http_client import TwilioHttpClient
 from . import s3_utils
 from odoo.addons.connect.models.license import ODUIST_MODULES
 ODUIST_MODULES.append('connect')
@@ -51,6 +52,26 @@ TWILIO_EDGES = [
     ("tokyo", "Japan"),
     ("singapore", "Singapore"),
 ]
+
+DEFAULT_SIP_DOMAIN_SUFFIX = 'sip.twilio.com'
+DEFAULT_HOLD_MUSIC_URL = (
+    'http://twimlets.com/holdmusic?Bucket=com.twilio.music.classical'
+)
+
+
+class _RewriteHostHttpClient(TwilioHttpClient):
+    """Route Twilio SDK REST calls to a Twilio-compatible voice API host."""
+
+    def __init__(self, rewrite_host, **kwargs):
+        super().__init__(**kwargs)
+        self._rewrite_host = rewrite_host
+
+    def request(self, method, url, params=None, data=None, headers=None,
+                auth=None, timeout=None, allow_redirects=False):
+        url = urlunsplit(urlsplit(url)._replace(netloc=self._rewrite_host))
+        return super().request(method, url, params, data, headers, auth,
+                               timeout, allow_redirects)
+
 
 SYSTEM_VOICE_CHOICES = [
     # Basic voices (no SSML support, free)
@@ -252,6 +273,28 @@ class Settings(models.Model):
         ('au1', 'Australia'),
     ], default='us1', required=True)
     twilio_edge = fields.Selection(selection=TWILIO_EDGES, required=True, default='ashburn')
+    rest_api_host = fields.Char(
+        string="REST API Host",
+        help="Hostname of a Twilio-compatible voice API. Leave empty for Twilio. "
+             "When set, SDK REST traffic uses this host; region/edge are ignored.",
+    )
+    sip_domain_suffix = fields.Char(
+        string="SIP Domain Suffix",
+        help="SIP hostname suffix (subdomain.suffix). Empty = sip.twilio.com.",
+    )
+    default_hold_music_url = fields.Char(
+        string="Default Hold Music URL",
+        help="Hold/wait music for conferences. Empty = Twilio twimlets default.",
+    )
+    webrtc_provider = fields.Selection(
+        [
+            ('twilio', 'Twilio WebRTC (browser phone)'),
+            ('disabled', 'Disabled (SIP phones only)'),
+        ],
+        default='twilio',
+        required=True,
+        string="Browser Phone",
+    )
     account_sid = fields.Char(string="Account SID")
     auth_token = fields.Char(
         groups="base.group_erp_manager,connect.group_connect_webhook"
@@ -673,6 +716,59 @@ class Settings(models.Model):
         return res
 
     @api.model
+    def uses_compatible_rest_api(self):
+        return bool((self.get_param('rest_api_host') or '').strip())
+
+    @api.model
+    def normalized_sip_domain_suffix(self):
+        suffix = (self.get_param('sip_domain_suffix') or '').strip().lstrip('.')
+        return suffix or DEFAULT_SIP_DOMAIN_SUFFIX
+
+    @api.model
+    def format_sip_domain_name(self, subdomain):
+        return '{}.{}'.format(subdomain, self.normalized_sip_domain_suffix())
+
+    @api.model
+    def format_sip_edge_domain(self, subdomain, edge):
+        suffix = self.normalized_sip_domain_suffix()
+        if suffix == DEFAULT_SIP_DOMAIN_SUFFIX and edge:
+            return '{}.sip.{}.twilio.com'.format(subdomain, edge)
+        return self.format_sip_domain_name(subdomain)
+
+    @api.model
+    def format_sip_connect_uri(self, username, subdomain, edge=None):
+        suffix = self.normalized_sip_domain_suffix()
+        if suffix == DEFAULT_SIP_DOMAIN_SUFFIX and edge and edge != 'roaming':
+            return '{}@{}.sip.{}.twilio.com'.format(username, subdomain, edge)
+        return '{}@{}'.format(username, self.format_sip_domain_name(subdomain))
+
+    @api.model
+    def get_default_hold_music_url(self):
+        url = (self.get_param('default_hold_music_url') or '').strip()
+        return url or DEFAULT_HOLD_MUSIC_URL
+
+    @api.model
+    def is_webrtc_enabled(self):
+        return self.get_param('webrtc_provider') != 'disabled'
+
+    @api.model
+    def parse_sip_to_user(self, to_val):
+        if not isinstance(to_val, str) or not to_val.startswith('sip:'):
+            return None
+        at = to_val.find('@')
+        if at == -1:
+            return None
+        user_part = to_val[4:at]
+        host_part = to_val[at + 1:]
+        suffix = self.normalized_sip_domain_suffix()
+        if suffix == DEFAULT_SIP_DOMAIN_SUFFIX:
+            if re.match(r'^.+\.sip(\.[^.]+)?\.twilio\.com$', host_part):
+                return user_part
+        elif host_part == suffix or host_part.endswith('.' + suffix):
+            return user_part
+        return None
+
+    @api.model
     def get_system_voice(self):
         """Get the system-wide voice setting for all TwiML say() calls"""
         voice = self.sudo().get_param('system_voice', 'man')
@@ -725,11 +821,14 @@ class Settings(models.Model):
             )
             account_sid = self.sudo().get_param("account_sid")
             auth_token = self.sudo().get_param("auth_token")
-            client = Client(account_sid, auth_token)
-            if region:
+            rest_api_host = (self.sudo().get_param("rest_api_host") or "").strip()
+            token_to_use = auth_token
+            if region and not rest_api_host:
                 region_auth_token = self.sudo().get_param("region_auth_token")
                 token_to_use = region_auth_token if region_auth_token else auth_token
-                client = Client(account_sid, token_to_use)
+            http_client = _RewriteHostHttpClient(rest_api_host) if rest_api_host else None
+            client = Client(account_sid, token_to_use, http_client=http_client)
+            if region and not rest_api_host:
                 twilio_region = self.sudo().get_param("twilio_region")
                 if twilio_region:
                     client.region = twilio_region

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -15,7 +15,7 @@ if release.version_info[0] >= 19:
 from twilio.jwt.access_token import AccessToken
 from twilio.jwt.access_token.grants import VoiceGrant
 from twilio.twiml.voice_response import Client, Dial, VoiceResponse
-from .settings import format_connect_response, debug, TWILIO_EDGES
+from .settings import format_connect_response, debug, TWILIO_EDGES, DEFAULT_SIP_DOMAIN_SUFFIX
 from .twiml import pretty_xml
 
 logger = logging.getLogger(__name__)
@@ -110,13 +110,16 @@ class User(models.Model):
         settings = self.env['connect.settings']
         default_edge = settings.get_param('twilio_edge') or 'roaming'
         for rec in self:
+            if not rec.username or not rec.domain or not rec.domain.subdomain:
+                rec.uri = ''
+                rec.connect_uri = ''
+                continue
             edge = rec.twilio_edge or default_edge
-            # Render URI is always global
             rec.uri = '{}@{}'.format(rec.username, rec.domain.domain_name)
-            if edge == 'roaming':
-                rec.connect_uri = '{}@{}'.format(rec.username, rec.domain.domain_name)
+            if edge == 'roaming' or settings.normalized_sip_domain_suffix() != DEFAULT_SIP_DOMAIN_SUFFIX:
+                rec.connect_uri = rec.uri
             else:
-                rec.connect_uri = '{}@{}.sip.{}.twilio.com'.format(
+                rec.connect_uri = settings.format_sip_connect_uri(
                     rec.username, rec.domain.subdomain, edge)
 
     def _create_sip_account(self, username, password, client=None):
@@ -543,6 +546,8 @@ class User(models.Model):
                 return {'token': False}
             if not user.client_enabled:
                 logger.info("Client for user %s not enabled!", self.env.user.id)
+                return {'token': False}
+            if not self.env['connect.settings'].is_webrtc_enabled():
                 return {'token': False}
             account_sid = self.env['connect.settings'].sudo().get_param('account_sid')
             api_key = self.env['connect.settings'].sudo().get_param('twilio_api_key')

--- a/connect/views/settings.xml
+++ b/connect/views/settings.xml
@@ -48,7 +48,11 @@
                        <field name="display_region_auth_token" string="Region Auth Token" password="1" invisible="twilio_region == 'us1'" required="twilio_region != 'us1'"/>
                        <field name="twilio_api_key" string="API Key SID"/>
                        <field name="display_twilio_api_secret" string="API Key Secret" password="1"/>
-                       <field name="twilio_edge" string="Edge"/>
+                       <field name="twilio_edge" string="Edge" invisible="rest_api_host"/>
+                       <field name="rest_api_host" string="REST API Host" placeholder="Leave empty for Twilio"/>
+                       <field name="sip_domain_suffix" string="SIP Domain Suffix" placeholder="sip.twilio.com (default)"/>
+                       <field name="default_hold_music_url" string="Default Hold Music URL" placeholder="Twilio twimlets default when empty"/>
+                       <field name="webrtc_provider" string="Browser Phone"/>
                        <button colspan="2" name="sync" type="object" string="SYNC TWILIO ACCOUNT" class="btn btn-primary"/>
                      </group>
                     <group name="openai_api" string="OpenAI">


### PR DESCRIPTION
## Summary

Minimal patch for **oduist/connect_addons @ 19.0** (Connect **2.0.2**): optional settings for a Twilio-compatible voice API. **6 files, +135 / −20 lines.**

Adds (not present in upstream oduist today):

- **`rest_api_host`** + `_RewriteHostHttpClient` — route Twilio SDK REST to a compatible provider
- **`sip_domain_suffix`**, **`default_hold_music_url`**, **`webrtc_provider`**
- Helpers + wiring in `domain.py`, `user.py`, `number.py`, `outgoing_callerid.py`
- Admin fields on **Settings → API Keys**

Empty fields → standard Twilio behaviour.

## Relation to HarrisonConsulting fork

[HarrisonConsulting/connect_addons](https://github.com/HarrisonConsulting/connect_addons) already includes `rest_api_host`; this PR ports a similar compat layer onto **official oduist 19.0**. Harrison-specific pieces (park slot, transfer twimlets wiring, extra tests) are omitted here because oduist 2.0.2 does not include those modules/paths.

## Backwards compatibility (intended)

| Empty / default | Behaviour |
|-----------------|-----------|
| `rest_api_host` | Twilio SDK unchanged |
| `sip_domain_suffix` | `*.sip.twilio.com` |
| `default_hold_music_url` | Twilio twimlets default (for future call sites) |
| `webrtc_provider=twilio` | Browser phone unchanged |

## Verification required — possibly breaking

Please test before merge: SIP URIs, inbound routing, `get_client()` auth, US1 guards when REST host is set.

- [ ] Pure Twilio, all new fields empty
- [ ] Compatible REST host configured
- [ ] `webrtc_provider=disabled`

## Customer-configurable hold music

`default_hold_music_url` replaces the need to hardcode twimlets URLs in code as compatible providers are adopted. oduist 2.0.2 has fewer conference-hold call sites than community forks; this field is exposed for configuration and for follow-up wiring where TwiML uses `waitUrl`.