### PR TITLE
[connect_elevenlabs] heal orphaned seed agent tools on install/upgrade (backport 15.0)

### DIFF
--- a/connect_elevenlabs/__init__.py
+++ b/connect_elevenlabs/__init__.py
@@ -1,5 +1,6 @@
 from . import controllers
 from . import models
+from .hooks import pre_init_hook, relink_orphan_agent_tools
 
 import logging
 from odoo import fields, api

--- a/connect_elevenlabs/__manifest__.py
+++ b/connect_elevenlabs/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Connect ElevenLabs',
-    'version': '1.0.5',
+    'version': '1.0.6',
     'author': 'Oduist',
     'price': 0,
     'currency': 'EUR',
@@ -49,5 +49,6 @@
     'assets': {
         'web.assets_backend': [],
     },
+    'pre_init_hook': 'pre_init_hook',
     'post_init_hook': 'post_init_hook',
 }

--- a/connect_elevenlabs/hooks.py
+++ b/connect_elevenlabs/hooks.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+from xml.etree import ElementTree as ET
+
+from odoo import api
+from odoo.api import SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+_MODULE = 'connect_elevenlabs'
+_MODEL = 'connect.elevenlabs_agent_tool'
+_TABLE = 'connect_elevenlabs_agent_tool'
+
+
+def _env_from_args(args):
+    """Resolve an Environment from pre_init_hook arguments across Odoo versions.
+
+    Odoo 17+ calls ``pre_init_hook(env)``; Odoo <= 16 calls ``pre_init_hook(cr)``
+    with a bare cursor. Detect the type instead of the argument count so a single
+    cursor argument is never mistaken for an Environment (which would otherwise
+    break the install path on Odoo 15 and 16).
+    """
+    obj = args[0]
+    if isinstance(obj, api.Environment):
+        return obj
+    return api.Environment(obj, SUPERUSER_ID, {})
+
+
+def _seed_tool_xmlids():
+    """Return ``{xml_id: name}`` for every agent tool declared in data/tools.xml.
+
+    Parsed from the shipped data file so the heal never drifts when seed tools
+    are added or removed.
+    """
+    tools_xml = os.path.join(os.path.dirname(__file__), 'data', 'tools.xml')
+    mapping = {}
+    for record in ET.parse(tools_xml).getroot().iter('record'):
+        if record.get('model') != _MODEL:
+            continue
+        xml_id = record.get('id')
+        name_field = record.find("field[@name='name']")
+        if xml_id and name_field is not None and name_field.text:
+            mapping[xml_id] = name_field.text.strip()
+    return mapping
+
+
+def relink_orphan_agent_tools(env):
+    """Restore missing ir.model.data links for seed agent tools.
+
+    A tool row can outlive its ir.model.data entry (uninstall leftovers, a
+    partial database restore, manual cleanup). Without the XML-ID the next
+    install/upgrade tries to INSERT the seed record from data/tools.xml and
+    fails on the UNIQUE(name) constraint. Re-creating the link lets the data
+    loader fall back to UPDATE instead of INSERT.
+
+    Safe to call repeatedly and on a fresh install (the table may not exist
+    yet, in which case there is nothing to heal).
+    """
+    cr = env.cr
+    cr.execute("SELECT to_regclass(%s)", [_TABLE])
+    if not cr.fetchone()[0]:
+        # First install: the table does not exist yet, nothing to re-link.
+        return
+
+    relinked = 0
+    for xml_id, name in _seed_tool_xmlids().items():
+        cr.execute(
+            """
+            INSERT INTO ir_model_data (module, name, model, res_id, noupdate, create_date, write_date)
+                 SELECT %(module)s, %(xml_id)s, %(model)s, t.id, FALSE, now(), now()
+                   FROM connect_elevenlabs_agent_tool t
+                  WHERE t.name = %(name)s
+                    AND NOT EXISTS (
+                            SELECT 1 FROM ir_model_data d
+                             WHERE d.module = %(module)s
+                               AND d.name = %(xml_id)s
+                               AND d.model = %(model)s
+                        )
+            """,
+            {'module': _MODULE, 'xml_id': xml_id, 'model': _MODEL, 'name': name},
+        )
+        relinked += cr.rowcount
+
+    if relinked:
+        _logger.info(
+            "Re-linked %d orphaned ElevenLabs agent tool(s) to their XML-IDs.", relinked)
+
+
+def pre_init_hook(*args):
+    """Heal orphaned seed tools before the module data files load on install."""
+    relink_orphan_agent_tools(_env_from_args(args))

--- a/connect_elevenlabs/migrations/1.0.6/pre-migrate.py
+++ b/connect_elevenlabs/migrations/1.0.6/pre-migrate.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import api, SUPERUSER_ID
+from odoo.addons.connect_elevenlabs.hooks import relink_orphan_agent_tools
+
+
+def migrate(cr, version):
+    """Re-link orphaned seed agent tools before data/tools.xml is loaded.
+
+    Covers the upgrade path; the install path is handled by ``pre_init_hook``.
+    Both call the same helper.
+    """
+    if not version:
+        return
+    relink_orphan_agent_tools(api.Environment(cr, SUPERUSER_ID, {}))


### PR DESCRIPTION

## What

Backport of #132 to the **15.0** branch.

A `connect.elevenlabs_agent_tool` row can outlive its `ir.model.data` entry
(uninstall leftovers, partial DB restore, manual cleanup). Without the XML-ID the
next install/upgrade re-`INSERT`s the seed record from `data/tools.xml` and fails
on `UNIQUE(name)`:

```
duplicate key value violates unique constraint
"connect_elevenlabs_agent_tool_name_unique"
DETAIL: Key (name)=(language_detection) already exists.
```

We relink the missing `ir.model.data` (matched by the unique name, xmlid↔name parsed
from `data/tools.xml`) before the data file loads, so the loader falls back to `UPDATE`.

- `pre_init_hook` → install path
- `migrations/1.0.6/pre-migrate.py` → upgrade path
- one shared helper; idempotent; safe on a fresh install (table may not exist yet)

## Version note (why this isn't a plain cherry-pick)

`pre_init_hook` signatures differ across Odoo (verified against core `modules/loading.py`):

| Odoo | `pre_init_hook` |
|------|-----------------|
| 15.0 / 16.0 | `(cr)` — bare cursor |
| 17.0+ | `(env)` |

The original `_env_from_args` assumed *single arg = env*. **On Odoo 15 that is exactly the broken case: `pre_init_hook` is called with a single bare cursor, which the old helper would treat as an Environment and crash the install on `env.cr`.** So the helper is
made **type-safe** (`isinstance(obj, api.Environment)` instead of `len(args)`): a bare
cursor is wrapped into an Environment, an env is used as-is. Correct on every supported
version; applied here for parity across all branches.

## Test plan

- [ ] Fresh install of `connect_elevenlabs` succeeds.
- [ ] Upgrade with a deleted `ir.model.data` for `agent_tool_language_detection` succeeds (no `duplicate key`).
- [ ] Repeated upgrade is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
