### PR TITLE
[connect] Fix AI completion composer patch crashing Chatter on Odoo 18 (#137)

### DIFF
--- a/connect/static/src/core/common/composer.js
+++ b/connect/static/src/core/common/composer.js
@@ -2,17 +2,18 @@
 "use strict"
 
 import {patch} from "@web/core/utils/patch"
+import {rpc} from "@web/core/network/rpc"
 import {Composer} from "@mail/core/common/composer"
 
 
 patch(Composer.prototype, {
     async _onClickAiCompletion() {
-        const response = await this.rpc("/connect/ai_completion", {
+        const response = await rpc("/connect/ai_completion", {
             model: this.thread.model,
             res_id: this.thread.id,
         })
         if (response.status === 'ok') {
-            this.props.composer.textInputContent = response.message
+            this.props.composer.text = response.message
         } else {
             this.env.services.notification.add(response.error_message, {type: "warning",})
         }

--- a/connect/static/src/core/common/composer.xml
+++ b/connect/static/src/core/common/composer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-inherit="mail.Composer" t-inherit-mode="extension">
+    <t t-inherit="mail.Composer.attachFiles" t-inherit-mode="extension">
         <xpath expr="//FileUploader" position="after">
-            <button class="btn border-0 rounded-pill" t-on-click="_onClickAiCompletion" title="AI Completion" aria-label="AI Completion" type="button">
-                <i class="fa fa-microchip"/>
+            <button class="btn border-0 rounded-circle p-0" t-on-click="_onClickAiCompletion" title="AI Completion" aria-label="AI Completion" type="button">
+                <i class="fa fa-fw fa-lg fa-microchip"/>
             </button>
         </xpath>
     </t>


### PR DESCRIPTION
## Summary

Fixes #137 — on Odoo 18 the Connect AI-completion composer patch crashed **every** Chatter composer (helpdesk tickets, sales orders, partners, …) with an uncaught Owl lifecycle error, blocking users from sending messages.

## Root cause

The patch inherited `mail.Composer` and xpath'd `//FileUploader`, but on Odoo 18 `FileUploader` is **not** a child of `mail.Composer` — it lives in the `mail.Composer.attachFiles` sub-template (pulled in via `t-call`). The xpath could not be resolved when the asset bundle's owl templates were assembled, so Owl threw and the whole Chatter component tree failed to render.

Two further Odoo 18 API mismatches in the JS patch:
- `this.rpc(...)` — `Composer` has no `this.rpc`; in 18 `rpc` is imported from `@web/core/network/rpc`.
- `this.props.composer.textInputContent` — the composer model field is `text`.

## Changes

- `composer.xml`: inherit `mail.Composer.attachFiles` instead of `mail.Composer` (keeps the `//FileUploader` anchor, now resolvable); align AI button styling with sibling actions.
- `composer.js`: import and use `rpc()`; write the result to `composer.text`.

## Verification (Odoo 18.0, live)

- **Before** (reverted to the buggy template): opening a contact + Send message → Owl lifecycle error, Chatter fails — reproduced.
- **After**: Chatter renders; the AI Completion button appears next to the attach control; clicking it calls `/connect/ai_completion` and, with no OpenAI key configured, correctly shows the "Missing OpenAI API key!" warning notification (proves the `rpc()` path and error branch). No console errors.