### PR TITLE
connect: archive/unarchive support for Connect User (ODU-272)

### DIFF
--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -54,6 +54,7 @@ class User(models.Model):
     _description = 'Connect User'
     _order = 'username'
 
+    active = fields.Boolean(default=True)
     sid = fields.Char('SID', readonly=True)
     callflow = fields.One2many('connect.user_callflow', 'user')
     exten = fields.Many2one('connect.exten', ondelete='set null', readonly=True)
@@ -310,6 +311,19 @@ class User(models.Model):
             return res
         if 'username' in vals:
             raise ValidationError('Username cannot be changed!')
+        # Telephony sync on archive/unarchive.
+        archiving = 'active' in vals and not vals['active']
+        unarchiving = 'active' in vals and vals['active']
+        sync_active = (self.env['connect.settings'].get_param('twilio_auto_sync')
+                       and not self.env.context.get('no_twilio_create'))
+        if archiving:
+            # Remove the SIP account so an archived user cannot use telephony.
+            if sync_active:
+                for rec in self:
+                    if rec.sid:
+                        rec.delete_sip_account()
+            # Drop the stale SID so the account is recreated cleanly on restore.
+            vals['sid'] = False
         for rec in self:
             if vals.get('password'):
                 # Check if twilio_auto_sync is disabled
@@ -324,7 +338,20 @@ class User(models.Model):
                     # Don't keep SIP password in Odoo.
                     vals['password'] = '*' * len(vals['password'])
         res = super().write(vals)
-        self.manage_group()
+        if unarchiving and sync_active:
+            # Recreate the SIP account with a fresh password (the original one
+            # is not stored in Odoo and cannot be recovered from Twilio).
+            for rec in self:
+                if rec.sip_enabled and not rec.sid:
+                    password = self.generate_twilio_password()
+                    rec.with_context(skip_sync=True, no_clear_cache=True).write({
+                        'sid': rec._create_sip_account(rec.username, password),
+                        'password': '*' * len(password),
+                    })
+        if archiving:
+            self.manage_group('remove')
+        else:
+            self.manage_group()
         if res and not self.env.context.get('no_clear_cache'):
             if release.version_info[0] >= 17:
                 self.env.registry.clear_cache()

--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import test_s3_utils
 from . import test_s3_settings
+from . import test_user_archive

--- a/connect/tests/test_user_archive.py
+++ b/connect/tests/test_user_archive.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch, MagicMock
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUserArchive(TransactionCase):
+    """Archiving a Connect User must remove its telephony access (SIP account +
+    Connect groups); unarchiving must recreate the SIP account with a fresh
+    password. See ODU-272."""
+
+    def setUp(self):
+        super().setUp()
+        self.env["connect.settings"].set_param("twilio_auto_sync", True)
+        self.domain = self.env["connect.domain"].create({
+            "subdomain": "testarchive",
+            "friendly_name": "Test Archive",
+            "cred_list_sid": "CLtest",
+        })
+        self.res_user = self.env["res.users"].create({
+            "name": "Arch Test",
+            "login": "archtest@example.com",
+        })
+
+    def _make_client(self, create_sid="CRnew"):
+        client = MagicMock()
+        client.sip.credential_lists.return_value.credentials.create.return_value.sid = create_sid
+        return client
+
+    def _patch_client(self, client):
+        return patch.object(
+            type(self.env["connect.settings"]), "get_client", return_value=client)
+
+    def _create_user(self, client):
+        with self._patch_client(client):
+            return self.env["connect.user"].create({
+                "username": "archuser",
+                "domain": self.domain.id,
+                "user": self.res_user.id,
+                "sip_enabled": True,
+                "password": "StrongPassw0rd1",
+            })
+
+    def test_create_provisions_sip_and_group(self):
+        user = self._create_user(self._make_client("CRnew"))
+        self.assertEqual(user.sid, "CRnew")
+        self.assertTrue(self.res_user.has_group("connect.group_connect_user"))
+
+    def test_archive_deletes_sip_and_removes_group(self):
+        client = self._make_client()
+        user = self._create_user(client)
+        with self._patch_client(client):
+            user.action_archive()
+        self.assertFalse(user.active)
+        # SID cleared so the account is recreated cleanly on restore.
+        self.assertFalse(user.sid)
+        client.sip.credential_lists.return_value.credentials.return_value.delete.assert_called_once()
+        # Telephony access revoked at the Odoo level too.
+        self.assertFalse(self.res_user.has_group("connect.group_connect_user"))
+
+    def test_unarchive_recreates_sip_with_new_password(self):
+        user = self._create_user(self._make_client())
+        with self._patch_client(self._make_client()):
+            user.action_archive()
+        self.assertFalse(user.sid)
+
+        restore_client = self._make_client(create_sid="CRrestored")
+        with self._patch_client(restore_client):
+            user.action_unarchive()
+
+        self.assertTrue(user.active)
+        self.assertEqual(user.sid, "CRrestored")
+        restore_client.sip.credential_lists.return_value.credentials.create.assert_called_once()
+        self.assertTrue(self.res_user.has_group("connect.group_connect_user"))
+
+    def test_archived_user_is_not_routable(self):
+        user = self._create_user(self._make_client())
+        with self._patch_client(self._make_client()):
+            user.action_archive()
+        # Default active_test excludes archived users from call routing lookups.
+        found = self.env["connect.user"].get_user_by_uri("sip:archuser@example.com")
+        self.assertFalse(found)
+        self.assertFalse(
+            self.env["connect.user"].search([("username", "=", "archuser")]))

--- a/connect/tests/test_user_archive.py
+++ b/connect/tests/test_user_archive.py
@@ -13,11 +13,12 @@ class TestUserArchive(TransactionCase):
     def setUp(self):
         super().setUp()
         self.env["connect.settings"].set_param("twilio_auto_sync", True)
-        self.domain = self.env["connect.domain"].create({
-            "subdomain": "testarchive",
-            "friendly_name": "Test Archive",
-            "cred_list_sid": "CLtest",
-        })
+        self.domain = self.env["connect.domain"].with_context(
+            no_twilio_create=True).create({
+                "subdomain": "testarchive",
+                "friendly_name": "Test Archive",
+                "cred_list_sid": "CLtest",
+            })
         self.res_user = self.env["res.users"].create({
             "name": "Arch Test",
             "login": "archtest@example.com",

--- a/connect/views/user.xml
+++ b/connect/views/user.xml
@@ -17,7 +17,8 @@
         <field name="name">connect.user_list</field>
         <field name="model">connect.user</field>
         <field name="arch" type="xml">
-            <list>
+            <list decoration-muted="not active">
+                <field name="active" column_invisible="1"/>
                 <field name="username"/>
                 <field name="user"/>
                 <field name="exten_number" string="Exten"/>
@@ -32,6 +33,19 @@
         </field>
     </record>
 
+    <record id="connect_user_search" model="ir.ui.view">
+        <field name="name">connect.user_search</field>
+        <field name="model">connect.user</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="username"/>
+                <field name="user"/>
+                <field name="exten_number" string="Exten"/>
+                <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+            </search>
+        </field>
+    </record>
+
     <record id="connect_user_form" model="ir.ui.view" >
         <field name="name">connect_user_form</field>
         <field name="model">connect.user</field>
@@ -41,6 +55,9 @@
                     <button name="create_extension" type="object" string="Extension" class="btn btn-primary"/>
                 </header>
                 <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger"
+                            invisible="active"/>
+                    <field name="active" invisible="1"/>
                     <div class="oe_title">
                         <h1>
                             <label class="oe_edit_only" for="user"/>


### PR DESCRIPTION
Assignee: [Max Li](https://linear.app/oduist/profile)

## Summary

Adds archive/unarchive support to **Connect User** (`connect.user`), implementing [ODU-272](https://linear.app/oduist/issue/ODU-272/archive-dlya-connect-user).

When a Connect User is archived, they disappear from lists and can no longer use telephony; unarchiving restores full telephony access at any time.

## Approach

- **New `active` field** on `connect.user` — enables Odoo's native archive/unarchive.
- **On archive** (`write({'active': False})`, incl. `action_archive`/`toggle_active`):
  - Deletes the Twilio SIP credential via the existing `delete_sip_account()`.
  - Clears the stored `sid` so restore is clean.
  - Removes the linked Odoo user from the Connect groups (`manage_group('remove')`).
  - The `active` field automatically excludes the user from call-routing lookups (`get_user_by_uri`, etc.), so archived users can neither place nor receive calls.
- **On unarchive** (`write({'active': True})`):
  - Recreates the SIP account with a **freshly generated password** (`generate_twilio_password()`). The original SIP password is intentionally never stored in Odoo and cannot be read back from Twilio, so a new one is generated — SIP hardware/softphones must be reconfigured after restore; the web phone (token auth) is unaffected.
  - Restores Connect group membership.
- All Twilio side effects respect the existing `twilio_auto_sync` setting and `no_twilio_create` context flag.
- **Views**: archived ribbon on the form, an "Archived" search filter, and muted styling for archived rows in the list.

Per the issue discussion: the Odoo `res.users` account is **not** archived (no cascade) — this affects telephony only.

## Testing

Added `connect/tests/test_user_archive.py` (4 tests, all passing) covering:
- create provisions SIP account + group
- archive deletes SIP account, clears SID, removes group
- unarchive recreates SIP account with a new password and restores group
- archived user is not routable (`get_user_by_uri` / search return empty)

Verified via `run_odoo_tests` on an Odoo 19 environment. The only failing test in the module (`TestS3Settings.test_aws_s3_url_compute`) is pre-existing and unrelated (environment/template S3 config; untouched by this branch).

## Linear

[ODU-272 — Archive для Connect User](https://linear.app/oduist/issue/ODU-272/archive-dlya-connect-user)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
