### PR TITLE
[SYNC] connect: bring the event-queue rework back from the vendored fork

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Connect",
-    "version": "2.0.3",
+    "version": "2.0.6",
     "author": "Oduist",
     "maintainer": "Oduist",
     "live_test_url": "https://connect-demo.oduist.com/",

--- a/connect/controllers/main.py
+++ b/connect/controllers/main.py
@@ -3,13 +3,13 @@
 import json
 import logging
 import os
-from datetime import timedelta
 
 import openai
 import requests
+from twilio.request_validator import RequestValidator
 from werkzeug.exceptions import NotFound
 
-from odoo import fields, http, release, tools
+from odoo import http, release, tools
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.addons.connect.models import s3_utils
@@ -19,6 +19,21 @@ logger = logging.getLogger(__name__)
 route_type = "json" if release.version_info[0] < 19.0 else 'jsonrpc'
 
 class ConnectController(http.Controller):
+
+    @staticmethod
+    def _check_twilio_signature(data):
+        settings = http.request.env['connect.settings'].sudo()
+        if not settings.get_param('twilio_verify_requests'):
+            return True
+        auth_token = (
+            settings.get_param('region_auth_token')
+            or settings.get_param('auth_token')
+        )
+        validator = RequestValidator(auth_token)
+        url = http.request.httprequest.url.replace('http:', 'https:')
+        signature = http.request.httprequest.headers.get(
+            'X-Twilio-Signature', '')
+        return validator.validate(url, data, signature)
 
     @http.route('/connect/transcript/<int:rec_id>', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
@@ -89,17 +104,22 @@ class ConnectController(http.Controller):
 
     @http.route('/connect/dial_complete', methods=['GET', 'POST'], type='http', auth='public', csrf=False)
     def dial_complete_handler(self, **kw):
-        """Handle Dial action completion for transfer redirects and update call completion fields"""
+        """Ingest transfer completion and return its immediate TwiML branch."""
         from twilio.twiml.voice_response import VoiceResponse
 
+        if not self._check_twilio_signature(kw):
+            return '<Response><Say>Invalid Twilio request!</Say></Response>'
         dial_status = kw.get('DialCallStatus')
         dial_call_sid = kw.get('DialCallSid')
         original_call_sid = kw.get('CallSid')
 
-        try:
-            self._process_extension_redirect_completion(kw)
-        except Exception as e:
-            logger.error(f'Failed to process transfer completion: {e}', exc_info=True)
+        event_payload = dict(kw, ConnectActionModel='connect.call')
+        http.request.env['connect.call.event'].sudo().ingest(
+            'dial_action',
+            event_payload,
+            token=http.request.httprequest.headers.get(
+                'I-Twilio-Idempotency-Token'),
+        )
 
         response = VoiceResponse()
 
@@ -159,55 +179,27 @@ class ConnectController(http.Controller):
 
         return response.to_xml()
 
-    def _process_extension_redirect_completion(self, webhook_params):
-        """
-        Process completion of extension redirect transfers.
-        Updates the original call's completion fields based on transfer outcome.
-        """
-        dial_call_status = webhook_params.get('DialCallStatus')
-        dial_call_sid = webhook_params.get('DialCallSid')
-        original_call_sid = webhook_params.get('CallSid')
-
-        original_call = self._find_original_call_for_redirect_completion(original_call_sid, dial_call_sid)
-        if not original_call:
-            logger.warning(f'Could not find original call for redirect completion')
-            return
-
-        transfer_recipient = None
-
-        if original_call_sid:
-            transfer_recipient = original_call.get_transfer_target(original_call_sid)
-
-        if not transfer_recipient and dial_call_sid:
-            transfer_recipient = original_call.get_transfer_target(dial_call_sid)
-
-        if not transfer_recipient:
-            parent_call_sid = webhook_params.get('ParentCallSid')
-            if parent_call_sid:
-                transfer_recipient = original_call.get_transfer_target(parent_call_sid)
-
-        if not transfer_recipient and original_call.transferred_users:
-            transfer_recipient = original_call.transferred_users[-1]
-
-        if not transfer_recipient:
-            logger.warning(f'Could not find transfer recipient for completion processing - no transferred_users found')
-            return
-
-        if dial_call_status == 'completed':
-            original_call.completed_by_user = transfer_recipient
-            self._create_or_update_transfer_channel(original_call, dial_call_sid, transfer_recipient, 'completed', webhook_params)
-            self._terminate_external_call_after_transfer_completion(original_call, dial_call_sid, transfer_recipient)
-        else:
-            self._create_or_update_transfer_channel(original_call, dial_call_sid, transfer_recipient, dial_call_status, webhook_params)
-
     def _find_original_call_for_redirect_completion(self, original_call_sid, dial_call_sid):
-        """Find the original call that initiated this transfer redirect"""
+        """Find the call from database-backed transfer runtime state."""
+        sid_values = [
+            sid for sid in (original_call_sid, dial_call_sid) if sid
+        ]
+        if sid_values:
+            attempt = http.request.env['connect.call.attempt'].sudo().search([
+                ('kind', '=', 'transfer'),
+                ('state', '=', 'pending'),
+                '|',
+                ('parent_sid', 'in', sid_values),
+                ('dial_call_sid', 'in', sid_values),
+            ], order='id desc', limit=1)
+            if attempt:
+                return attempt.call_id
+
+        # Compatibility fallback for calls created before the 2.0.3 migration.
         Call = http.request.env['connect.call'].sudo()
-        cutoff = fields.Datetime.now() - timedelta(minutes=5)
 
         recent_calls = Call.search([
             ('transfer_context', '!=', False),
-            ('create_date', '>=', cutoff),
         ])
 
         for call in recent_calls:
@@ -220,112 +212,10 @@ class ConnectController(http.Controller):
         # Fallback: find recent calls with transfers still in progress
         recent_transfers = Call.search([
             ('transferred_users', '!=', False),
-            ('create_date', '>=', cutoff),
             ('status', 'not in', ['completed', 'failed', 'busy', 'no-answer']),
         ], limit=5)
 
-        if recent_transfers:
-            return recent_transfers[0]
-
-        return None
-
-    def _create_or_update_transfer_channel(self, call, dial_call_sid, transfer_recipient, status, webhook_params):
-        """Create or update a channel record for the transfer recipient to ensure proper field population"""
-        try:
-            existing_channel = http.request.env['connect.channel'].sudo().search([
-                ('sid', '=', dial_call_sid),
-                ('call', '=', call.id)
-            ], limit=1)
-
-            if existing_channel:
-                logger.info(f'Updating existing transfer channel {existing_channel.id}')
-                existing_channel.write({
-                    'status': status,
-                    'duration': int(webhook_params.get('DialCallDuration', 0))
-                })
-                return existing_channel
-            else:
-                logger.info(f'Creating new transfer channel for {transfer_recipient.login}')
-
-                parent_channel = call.channels.filtered(lambda c: not c.parent_channel)
-                if not parent_channel:
-                    logger.warning(f'No parent channel found for call {call.id}')
-                    return None
-                parent_channel = parent_channel[0]
-
-                pbx_user = http.request.env['connect.user'].sudo().search([
-                    ('user', '=', transfer_recipient.id)
-                ], limit=1)
-
-                if not pbx_user:
-                    logger.warning(f'No PBX user found for {transfer_recipient.login}')
-                    return None
-
-                channel_data = {
-                    'sid': dial_call_sid,
-                    'call': call.id,
-                    'parent_channel': parent_channel.id,
-                    'technical_direction': 'outbound-dial',
-                    'status': status,
-                    'duration': int(webhook_params.get('DialCallDuration', 0)),
-                    'called_pbx_user': pbx_user.id,
-                    'called_user': transfer_recipient.id,
-                    'call_source': 'transfer',
-                    'caller': parent_channel.caller,
-                    'called': pbx_user.uri
-                }
-
-                new_channel = http.request.env['connect.channel'].sudo().create(channel_data)
-                logger.info(f'Created transfer channel {new_channel.id} for {transfer_recipient.login}')
-                return new_channel
-
-        except Exception as e:
-            logger.error(f'Failed to create/update transfer channel: {e}', exc_info=True)
-            return None
-
-    def _terminate_external_call_after_transfer_completion(self, call, transfer_recipient_sid, transfer_recipient):
-        """
-        Terminate external call legs after successful transfer completion to prevent voicemail fall-through.
-        This addresses the issue where external callers go to voicemail when internal users hang up completed calls.
-        """
-        try:
-            if call.direction == 'outgoing':
-                external_call_sid = call.get_external_call_leg()
-                if external_call_sid:
-                    client = http.request.env['connect.settings'].sudo().get_client()
-                    try:
-                        external_call = client.calls(external_call_sid).fetch()
-                        if external_call.status in ['in-progress', 'ringing']:
-                            self._store_external_call_termination_context(call, external_call_sid, transfer_recipient_sid)
-                        else:
-                            logger.info(f'External call {external_call_sid} already ended ({external_call.status})')
-                    except Exception as e:
-                        logger.warning(f'Could not check external call status: {e}')
-                else:
-                    logger.warning(f'No external call leg found for outgoing call {call.id}')
-            else:
-                external_channels = call.channels.filtered(lambda c: not c.parent_channel and not c.caller_pbx_user)
-                if external_channels:
-                    external_channel = external_channels[0]
-                    self._store_external_call_termination_context(call, external_channel.sid, transfer_recipient_sid)
-                else:
-                    logger.info(f'No external caller channel found for incoming call {call.id}')
-
-        except Exception as e:
-            logger.error(f'Failed to set up external call termination: {e}', exc_info=True)
-
-    def _store_external_call_termination_context(self, call, external_call_sid, transfer_recipient_sid):
-        """Store context for terminating external calls when transfer recipients hang up"""
-        try:
-            current_context = call.transfer_context or {}
-            current_context['_external_termination'] = {
-                'external_call_sid': external_call_sid,
-                'transfer_recipient_sid': transfer_recipient_sid,
-                'setup_time': http.request.env.cr.now()
-            }
-            call.transfer_context = current_context
-        except Exception as e:
-            logger.error(f'Failed to store external termination context: {e}')
+        return recent_transfers[:1]
 
     @http.route("/connect/ai_completion", type="json", auth="user")
     def ai_completion(self, model, res_id):

--- a/connect/controllers/twilio_webhooks.py
+++ b/connect/controllers/twilio_webhooks.py
@@ -11,6 +11,11 @@ logger = logging.getLogger(__name__)
 class ConnectController(Controller):
 
     @staticmethod
+    def _idempotency_token():
+        return request.httprequest.headers.get(
+            'I-Twilio-Idempotency-Token')
+
+    @staticmethod
     def check_signature(data, region=True):
         if not request.env['connect.settings'].sudo().get_param('twilio_verify_requests'):
             return True
@@ -42,8 +47,11 @@ class ConnectController(Controller):
     def callstatus_webhook(self, **kw):
         if not self.check_signature(kw):
             return Response("Twilio request is not valid!", status=500)
-        res = request.env['connect.call'].with_user(request.env.ref("connect.user_connect_webhook")).on_call_status(kw)
-        return f'{res}'
+        request.env['connect.call.event'].with_user(
+            request.env.ref("connect.user_connect_webhook")
+        ).ingest(
+            'call_status', kw, token=self._idempotency_token())
+        return Response("OK", status=200)
 
     @route('/twilio/webhook/number', methods=['POST'], type='http', auth='public', csrf=False)
     def number_webhook(self, **kw):
@@ -73,14 +81,25 @@ class ConnectController(Controller):
     def vm_recording_status_webhook(self, **kw):
         if not self.check_signature(kw):
             return '<Response><Say>Invalid Twilio request!</Say></Response>'
-        call = request.env['connect.call'].with_user(request.env.ref("connect.user_connect_webhook"))
-        res = call.on_vm_recording_status(kw)
-        return f'{res}'
+        request.env['connect.call.event'].with_user(
+            request.env.ref("connect.user_connect_webhook")
+        ).ingest(
+            'voicemail_status', kw, token=self._idempotency_token())
+        return Response("OK", status=200)
 
     @route('/twilio/webhook/<string:model_name>/call_action/<int:record_id>', methods=['POST'], type='http', auth='public', csrf=False)
     def call_action_edit_webhook(self, model_name, record_id, **kw):
         if not self.check_signature(kw):
             return '<Response><Say>Invalid Twilio request!</Say></Response>'
+        event_payload = dict(
+            kw,
+            ConnectActionModel=model_name,
+            ConnectActionRecordId=record_id,
+        )
+        request.env['connect.call.event'].with_user(
+            request.env.ref("connect.user_connect_webhook")
+        ).ingest(
+            'dial_action', event_payload, token=self._idempotency_token())
         model = request.env[model_name].with_user(request.env.ref("connect.user_connect_webhook"))
         res = model.on_call_action(record_id, kw)
         return f'{res}'
@@ -97,8 +116,22 @@ class ConnectController(Controller):
     def call_action_webhook(self, **kw):
         if not self.check_signature(kw):
             return '<Response><Say>Invalid Twilio request!</Say></Response>'
+        event_payload = dict(
+            kw,
+            ConnectActionModel='connect.call',
+        )
+        request.env['connect.call.event'].with_user(
+            request.env.ref("connect.user_connect_webhook")
+        ).ingest(
+            'dial_action', event_payload, token=self._idempotency_token())
+        return '<Response><Hangup/></Response>'
+
+    @route('/twilio/webhook/park_retrieve/<int:call_id>/<string:slot>', methods=['POST'], type='http', auth='public', csrf=False)
+    def park_retrieve_action_webhook(self, call_id, slot, **kw):
+        if not self.check_signature(kw):
+            return '<Response><Say>Invalid Twilio request!</Say></Response>'
         call = request.env['connect.call'].with_user(request.env.ref("connect.user_connect_webhook"))
-        res = call.on_call_action(kw)
+        res = call.on_park_retrieve_action(call_id, slot, kw)
         return f'{res}'
 
     @route('/twilio/webhook/twiml/<int:twiml_id>', methods=['POST'], type='http', auth='public', csrf=False)
@@ -135,6 +168,15 @@ class ConnectController(Controller):
     def callflow_ring_contact_manager_action(self, record_id, **kw):
         if not self.check_signature(kw):
             return '<Response><Say>Invalid Twilio request!</Say></Response>'
+        event_payload = dict(
+            kw,
+            ConnectActionModel='connect.callflow',
+            ConnectActionRecordId=record_id,
+        )
+        request.env['connect.call.event'].with_user(
+            request.env.ref("connect.user_connect_webhook")
+        ).ingest(
+            'dial_action', event_payload, token=self._idempotency_token())
         model = request.env['connect.callflow'].with_user(request.env.ref("connect.user_connect_webhook"))
         res = model.on_ring_contact_manager_action(record_id, kw)
         return f'{res}'
@@ -152,6 +194,14 @@ class ConnectController(Controller):
     def transfer_continuation_webhook(self, **kw):
         if not self.check_signature(kw):
             return '<Response><Say>Invalid Twilio request!</Say></Response>'
+        event_payload = dict(
+            kw,
+            ConnectActionModel='connect.call',
+        )
+        request.env['connect.call.event'].with_user(
+            request.env.ref("connect.user_connect_webhook")
+        ).ingest(
+            'dial_action', event_payload, token=self._idempotency_token())
         transfer_wizard = request.env['connect.transfer_wizard'].with_user(request.env.ref("connect.user_connect_webhook"))
         res = transfer_wizard.handle_transfer_continuation(kw)
         return f'{res}'

--- a/connect/data/ir_cron.xml
+++ b/connect/data/ir_cron.xml
@@ -20,5 +20,15 @@
             <field name="active">True</field>
         </record>
 
+        <record id="process_call_events" model="ir.cron">
+            <field name="name">Project Twilio Call Events</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">minutes</field>
+            <field name="model_id" ref="model_connect_call_event"/>
+            <field name="code">model.process_pending_events(limit=200)</field>
+            <field name="state">code</field>
+            <field name="active">True</field>
+        </record>
+
     </data>
 </odoo>

--- a/connect/migrations/2.0.6/post-migrate.py
+++ b/connect/migrations/2.0.6/post-migrate.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+
+from odoo import fields
+
+
+END_STATUSES = ("completed", "busy", "failed", "no-answer", "canceled")
+
+
+def _insert_attempt(
+    cr,
+    call_id,
+    kind,
+    parent_sid,
+    target_user_id=None,
+    dial_call_sid=None,
+    external_sid=None,
+    context=None,
+):
+    now = fields.Datetime.now()
+    # Skip attempts that are already there: this script also runs on databases
+    # that went through an earlier release of the same backfill.
+    cr.execute(
+        """
+        INSERT INTO connect_call_attempt (
+            kind, call_id, parent_sid, expected_count, target_user_id,
+            dial_call_sid, external_sid, state, expires_at, context,
+            create_uid, create_date, write_uid, write_date
+        )
+        SELECT
+            %(kind)s, %(call_id)s, %(parent_sid)s, 1, %(target_user_id)s,
+            %(dial_call_sid)s, %(external_sid)s, 'pending', %(expires_at)s,
+            %(context)s::jsonb, 1, %(now)s, 1, %(now)s
+         WHERE NOT EXISTS (
+             SELECT 1
+               FROM connect_call_attempt
+              WHERE call_id = %(call_id)s
+                AND kind = %(kind)s
+                AND target_user_id IS NOT DISTINCT FROM %(target_user_id)s::integer
+                AND dial_call_sid IS NOT DISTINCT FROM %(dial_call_sid)s::varchar
+                AND external_sid IS NOT DISTINCT FROM %(external_sid)s::varchar
+         )
+        """,
+        {
+            "kind": kind,
+            "call_id": call_id,
+            "parent_sid": parent_sid,
+            "target_user_id": target_user_id,
+            "dial_call_sid": dial_call_sid,
+            "external_sid": external_sid,
+            "expires_at": now + timedelta(hours=1),
+            "context": context,
+            "now": now,
+        },
+    )
+
+
+def migrate(cr, version):
+    """Backfill database-backed runtime state for unfinished legacy calls."""
+    cr.execute(
+        """
+        UPDATE connect_call
+           SET finalized_at = COALESCE(finalized_at, write_date, create_date),
+               registration_done = TRUE,
+               ring_notification_done = TRUE,
+               error_notification_done = COALESCE(has_error, FALSE)
+         WHERE status IN %s
+           AND finalized_at IS NULL
+        """,
+        (END_STATUSES,),
+    )
+
+    cr.execute(
+        """
+        SELECT id, call_sid, transfer_context
+          FROM connect_call
+         WHERE status IS NULL OR status NOT IN %s
+        """,
+        (END_STATUSES,),
+    )
+    for call_id, call_sid, context in cr.fetchall():
+        context = context or {}
+        for key, value in context.items():
+            if key == "_external_leg":
+                _insert_attempt(
+                    cr, call_id, "external_leg", call_sid, external_sid=value
+                )
+            elif key == "_external_termination" and isinstance(value, dict):
+                _insert_attempt(
+                    cr,
+                    call_id,
+                    "external_termination",
+                    call_sid,
+                    dial_call_sid=value.get("transfer_recipient_sid"),
+                    external_sid=value.get("external_call_sid"),
+                )
+            elif isinstance(value, dict) and value.get("user_id"):
+                _insert_attempt(
+                    cr,
+                    call_id,
+                    "transfer",
+                    call_sid,
+                    target_user_id=value["user_id"],
+                    dial_call_sid=key,
+                )
+
+    cr.execute(
+        """
+        SELECT relation.call_id, relation.user_id, call.call_sid
+          FROM connect_call_transfer_rel relation
+          JOIN connect_call call ON call.id = relation.call_id
+         WHERE (call.status IS NULL OR call.status NOT IN %s)
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM connect_call_attempt attempt
+                WHERE attempt.call_id = relation.call_id
+                  AND attempt.kind = 'transfer'
+                  AND attempt.target_user_id = relation.user_id
+           )
+        """,
+        (END_STATUSES,),
+    )
+    for call_id, user_id, call_sid in cr.fetchall():
+        _insert_attempt(
+            cr,
+            call_id,
+            "transfer",
+            call_sid,
+            target_user_id=user_id,
+        )

--- a/connect/models/__init__.py
+++ b/connect/models/__init__.py
@@ -10,6 +10,8 @@ See LICENSE and COPYRIGHT files for full terms.
 
 from . import s3_utils
 from . import call
+from . import call_attempt
+from . import call_event
 from . import callflow
 from . import ir_module_module
 from . import channel

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -94,6 +94,14 @@ class Call(models.Model):
         ('ring_group', 'Ring Group (Multiple Users)'),
         ('direct_call', 'Direct Call (Single User)')
     ], string='Call Pattern', readonly=True, help='Detected call pattern: ring group vs direct call')
+    # Call parking fields
+    park_slot = fields.Char(string='Parking Slot', readonly=True, index=True,
+        help='Parking slot the call is currently waiting in. Cleared when the call is retrieved.')
+    park_call_sid = fields.Char(string='Parked Call SID', readonly=True,
+        help='Twilio CallSid of the leg that was placed into the parking queue.')
+    parked_at = fields.Datetime(string='Parked At', readonly=True)
+    parked_by_pbx_user = fields.Many2one('connect.user', ondelete='set null',
+        string='Parked By', readonly=True)
     # Scheduled fields.
     scheduled_datetime = fields.Datetime()
     # Voicemail fields
@@ -118,6 +126,14 @@ class Call(models.Model):
     call_sid = fields.Char(string='Twilio Call SID', readonly=True, index=True, help='Twilio CallSid for fetching price information')
     is_price_fetched = fields.Boolean(string='Price Fetched', default=False, readonly=True, index=True, help='Indicates if call price has been fetched from Twilio API')
     price_fetch_attempts = fields.Integer(string='Price Fetch Attempts', default=0, readonly=True)
+    attempt_ids = fields.One2many(
+        'connect.call.attempt', 'call_id', string='Runtime Attempts', readonly=True)
+    projection_event_id = fields.Integer(readonly=True, index=True)
+    finalization_event_id = fields.Integer(readonly=True, index=True)
+    finalized_at = fields.Datetime(readonly=True, index=True)
+    registration_done = fields.Boolean(default=False, readonly=True, index=True)
+    ring_notification_done = fields.Boolean(default=False, readonly=True)
+    error_notification_done = fields.Boolean(default=False, readonly=True)
     pbx_group_user_ids = fields.Many2many(
         'res.users', 'connect_call_pbx_group_users_rel',
         string='PBX Group Users',
@@ -553,34 +569,15 @@ class Call(models.Model):
             logger.info(f"Call {self.id}: Fallback - answered_user={self.answered_user.login}, completed_by_user={self.completed_by_user.login}")
 
     def add_transferred_user(self, user):
-        """Add a user to the transferred_users field when a transfer is initiated."""
+        """Persist transfer runtime state so every worker observes it."""
         self.ensure_one()
         if user and hasattr(user, 'id'):
             current_transfer_ids = self.transferred_users.ids
             if user.id not in current_transfer_ids:
                 self.transferred_users = [(4, user.id)]
-                if hasattr(self.__class__, '_webhook_expectations'):
-                    call_key = f"call_{self.id}"
-                    expectations = self.__class__._webhook_expectations.get(call_key, {})
-                    if 'ring_group' in expectations:
-                        ring_expectation = expectations['ring_group']
-                        current_expected = ring_expectation.get('expected_count', 0)
-                        if current_expected > 1:
-                            new_expected = current_expected - 1
-                            ring_expectation['expected_count'] = new_expected
-                            logger.info(f"Call {self.id}: Reduced ring_group expectation from {current_expected} to {new_expected} due to transfer")
-                            all_call_sids = list(ring_expectation.get('call_sid_states', {}).keys())
-                            terminal_sids = [sid for sid, state in ring_expectation.get('call_sid_states', {}).items() if state.get('terminal', False)]
-                            if len(all_call_sids) >= new_expected and len(terminal_sids) >= new_expected:
-                                logger.info(f"Call {self.id}: ring_group expectation now fulfilled with reduced count - clearing expectation")
-                                del expectations['ring_group']
-                                if not expectations:
-                                    del self.__class__._webhook_expectations[call_key]
                 self._set_webhook_expectation('transfer', {
                     'expected_count': 1,
-                    'received_count': 0,
                     'target_user_id': user.id,
-                    'target_user_login': user.login
                 })
                 logger.info(f"Call {self.id}: Transfer initiated to {user.login} (added to transferred_users)")
                 if not self.call_pattern:
@@ -589,24 +586,40 @@ class Call(models.Model):
                         self.call_pattern = detected_pattern
 
     def store_transfer_context(self, dial_call_sid, target_user):
-        """Store temporary transfer context for webhook processing."""
+        """Store transfer context in the database (legacy JSON is read-only)."""
         self.ensure_one()
         if not dial_call_sid or not target_user:
             return
-        current_context = self.transfer_context or {}
-        current_context[dial_call_sid] = {
-            'user_id': target_user.id,
-            'user_login': target_user.login
-        }
-        self.transfer_context = current_context
+        attempt = self.attempt_ids.filtered(
+            lambda rec: rec.kind == 'transfer'
+            and rec.state == 'pending'
+            and rec.target_user_id == target_user
+        )[:1]
+        if attempt:
+            attempt.write({'dial_call_sid': dial_call_sid})
+        else:
+            self.env['connect.call.attempt'].sudo().create({
+                'kind': 'transfer',
+                'call_id': self.id,
+                'parent_sid': self.call_sid or self.channels[:1].sid,
+                'dial_call_sid': dial_call_sid,
+                'target_user_id': target_user.id,
+            })
         logger.info(f"Call {self.id}: Stored transfer context for {dial_call_sid} -> {target_user.login}")
 
     def get_transfer_target(self, dial_call_sid):
-        """Get transfer target from temporary context storage."""
+        """Get a transfer target from runtime attempts, then legacy JSON."""
         self.ensure_one()
-        if not self.transfer_context or not dial_call_sid:
+        if not dial_call_sid:
             return None
-        context_data = self.transfer_context.get(dial_call_sid)
+        attempt = self.attempt_ids.filtered(
+            lambda rec: rec.kind == 'transfer'
+            and rec.dial_call_sid == dial_call_sid
+            and rec.target_user_id
+        )[:1]
+        if attempt:
+            return attempt.target_user_id
+        context_data = (self.transfer_context or {}).get(dial_call_sid)
         if context_data and 'user_id' in context_data:
             user = self.env['res.users'].sudo().browse(context_data['user_id'])
             if user.exists():
@@ -615,161 +628,162 @@ class Call(models.Model):
         return None
 
     def store_external_call_leg(self, external_call_sid):
-        """Store external call leg SID for outgoing call transfers."""
+        """Store an external leg without mutating connect.call."""
         self.ensure_one()
         if not external_call_sid:
             return
-        current_context = self.transfer_context or {}
-        current_context['_external_leg'] = external_call_sid
-        self.transfer_context = current_context
+        attempt = self.attempt_ids.filtered(
+            lambda rec: rec.kind == 'external_leg' and rec.state == 'pending'
+        )[:1]
+        if attempt:
+            attempt.write({'external_sid': external_call_sid})
+        else:
+            self.env['connect.call.attempt'].sudo().create({
+                'kind': 'external_leg',
+                'call_id': self.id,
+                'parent_sid': self.call_sid or self.channels[:1].sid,
+                'external_sid': external_call_sid,
+            })
         logger.info(f"Call {self.id}: Stored external call leg SID: {external_call_sid}")
 
     def get_external_call_leg(self):
-        """Get external call leg SID for outgoing call transfers."""
+        """Get an external leg from runtime attempts, then legacy JSON."""
         self.ensure_one()
-        if not self.transfer_context:
-            return None
-        external_leg = self.transfer_context.get('_external_leg')
+        attempt = self.attempt_ids.filtered(
+            lambda rec: rec.kind == 'external_leg' and rec.external_sid
+        )[:1]
+        external_leg = attempt.external_sid if attempt else (
+            (self.transfer_context or {}).get('_external_leg'))
         if external_leg:
             logger.info(f"Call {self.id}: Retrieved external call leg SID: {external_leg}")
             return external_leg
         return None
 
     def clear_transfer_context(self):
-        """Clear temporary transfer context after call processing is complete."""
+        """Resolve runtime attempts; keep the legacy JSON field untouched."""
         self.ensure_one()
-        if self.transfer_context:
-            logger.info(f"Call {self.id}: Clearing transfer context")
-            self.transfer_context = None
-
-    @classmethod
-    def _cleanup_old_webhook_expectations(cls):
-        """Clean up old expectations (older than 10 minutes)"""
-        import datetime
-        if not hasattr(cls, '_webhook_expectations'):
-            return
-        cutoff = fields.Datetime.now() - datetime.timedelta(minutes=10)
-        to_remove = []
-        for call_key, expectations in cls._webhook_expectations.items():
-            empty_expectations = []
-            for source, data in expectations.items():
-                if data['timestamp'] < cutoff:
-                    empty_expectations.append(source)
-            for source in empty_expectations:
-                del expectations[source]
-            if not expectations:
-                to_remove.append(call_key)
-        for call_key in to_remove:
-            del cls._webhook_expectations[call_key]
-        if to_remove:
-            logger.info(f"Cleaned up webhook expectations for {len(to_remove)} completed calls")
+        self.attempt_ids.filtered(
+            lambda rec: rec.state == 'pending'
+        ).mark_resolved()
 
     def _set_webhook_expectation(self, source, data):
-        """Set expectation for incoming webhook data with per-CallSid tracking"""
-        import datetime
-        import random
-        if random.randint(1, 50) == 1:
-            self.__class__._cleanup_old_webhook_expectations()
-        if not hasattr(self.__class__, '_webhook_expectations'):
-            self.__class__._webhook_expectations = {}
-        call_key = f"call_{self.id}"
-        if call_key not in self.__class__._webhook_expectations:
-            self.__class__._webhook_expectations[call_key] = {}
+        """Create a persistent expectation shared by all Odoo workers."""
+        self.ensure_one()
+        kind = source if source in {
+            'direct_call', 'ring_group', 'transfer', 'external_leg',
+            'external_termination'
+        } else 'direct_call'
         expected_call_sids = data.get('expected_call_sids', [])
-        self.__class__._webhook_expectations[call_key][source] = {
-            'timestamp': fields.Datetime.now(),
+        vals = {
+            'kind': kind,
+            'call_id': self.id,
+            'parent_sid': self.call_sid or self.channels[:1].sid,
             'expected_count': data.get('expected_count', 1),
-            'received_count': 0,
-            'expected_call_sids': expected_call_sids,
-            'call_sid_states': {},
-            **{k: v for k, v in data.items() if k not in ['expected_count', 'received_count', 'expected_call_sids']}
+            'target_user_id': data.get('target_user_id'),
+            'dial_call_sid': expected_call_sids[0] if len(expected_call_sids) == 1 else False,
+            'context': data,
         }
+        attempt = self.env['connect.call.attempt'].sudo().create(vals)
         if expected_call_sids:
             logger.info(f"Call {self.id}: Set {source} webhook expectation - expecting CallSids: {expected_call_sids}")
         else:
             logger.info(f"Call {self.id}: Set {source} webhook expectation - expecting {data.get('expected_count', 1)} channels")
+        return attempt
 
     def _update_webhook_expectation_callsid(self, source, call_sid, call_status):
-        """Update CallSid state and check if expectation is complete based on terminal states"""
-        if not hasattr(self.__class__, '_webhook_expectations'):
-            return
-        call_key = f"call_{self.id}"
-        if call_key not in self.__class__._webhook_expectations:
-            return
-        expectations = self.__class__._webhook_expectations[call_key]
-        if source not in expectations:
-            return
-        expectation = expectations[source]
-        is_terminal = call_status in CALL_END_STATUSES
-        expectation['call_sid_states'][call_sid] = {
-            'status': call_status,
-            'terminal': is_terminal
-        }
-        logger.info(f"Call {self.id}: {source} CallSid tracking - {call_sid} status: {call_status} (terminal: {is_terminal})")
-        expected_count = expectation.get('expected_count', 1)
-        all_call_sids = list(expectation['call_sid_states'].keys())
-        terminal_sids = [sid for sid, state in expectation['call_sid_states'].items() if state['terminal']]
-        logger.info(f"Call {self.id}: {source} CallSids seen: {len(all_call_sids)}, terminal: {len(terminal_sids)}, expected: {expected_count}")
-        if len(all_call_sids) >= expected_count and len(terminal_sids) >= expected_count:
-            logger.info(f"Call {self.id}: {source} expectation fulfilled - all expected CallSids reached terminal states")
-            del expectations[source]
-            if not expectations:
-                logger.info(f"Call {self.id}: All webhook expectations complete - removing call from tracking")
-                del self.__class__._webhook_expectations[call_key]
-        else:
-            if len(all_call_sids) < expected_count:
-                reason = f"waiting for {expected_count - len(all_call_sids)} more CallSids"
-            else:
-                non_terminal = expected_count - len(terminal_sids)
-                reason = f"waiting for {non_terminal} CallSids to reach terminal state"
-            logger.info(f"Call {self.id}: {source} expectation not yet fulfilled - {reason}")
+        """Compatibility helper for code paths that still update a leg directly."""
+        attempts = self.attempt_ids.filtered(
+            lambda rec: rec.kind == source and rec.state == 'pending')
+        if call_status in CALL_END_STATUSES:
+            for attempt in attempts:
+                channels = self.channels.filtered(
+                    lambda channel: channel.call_source == source
+                    and channel.status in CALL_END_STATUSES)
+                if len(channels) >= attempt.expected_count:
+                    attempt.mark_resolved()
 
     def _has_pending_webhooks(self):
-        """Check if we're still expecting webhook data"""
-        if not hasattr(self.__class__, '_webhook_expectations'):
-            return False
-        call_key = f"call_{self.id}"
-        if call_key not in self.__class__._webhook_expectations:
-            return False
-        expectations = self.__class__._webhook_expectations[call_key]
-        if not expectations:
-            return False
-        import datetime
-        cutoff = fields.Datetime.now() - datetime.timedelta(seconds=60)
-        active_expectations = False
-        timed_out_sources = []
-        for source, data in expectations.items():
-            timestamp = data['timestamp']
-            if timestamp > cutoff:
-                active_expectations = True
-            else:
-                timed_out_sources.append(source)
-        for source in timed_out_sources:
-            logger.warning(f"Call {self.id}: {source} expectation timed out after 60 seconds")
-            del expectations[source]
-        if not expectations:
-            del self.__class__._webhook_expectations[call_key]
-        if timed_out_sources and not active_expectations:
-            logger.warning(f"Call {self.id}: All webhook expectations timed out, proceeding with finalization")
-        return active_expectations
+        """Check persistent, non-expired runtime expectations."""
+        now = fields.Datetime.now()
+        expired = self.attempt_ids.filtered(
+            lambda rec: rec.state == 'pending' and rec.expires_at <= now)
+        if expired:
+            expired.write({'state': 'expired', 'resolved_at': now})
+        return bool(self.attempt_ids.filtered(
+            lambda rec: rec.state == 'pending'
+            and rec.kind not in ('external_leg', 'external_termination')))
 
     def _clear_webhook_expectations(self, source=None):
-        """Clear webhook expectations for this call, optionally for a specific source"""
-        if not hasattr(self.__class__, '_webhook_expectations'):
-            return
-        call_key = f"call_{self.id}"
-        if call_key not in self.__class__._webhook_expectations:
-            return
-        if source:
-            expectations = self.__class__._webhook_expectations[call_key]
-            if source in expectations:
-                logger.info(f"Call {self.id}: Clearing {source} webhook expectation due to pattern change")
-                del expectations[source]
-                if not expectations:
-                    del self.__class__._webhook_expectations[call_key]
+        """Resolve persistent expectations, optionally filtered by kind."""
+        attempts = self.attempt_ids.filtered(
+            lambda rec: rec.state == 'pending'
+            and (not source or rec.kind == source))
+        attempts.mark_resolved()
+
+    @api.model
+    def ensure_initial_call(self, payload):
+        """Synchronously and idempotently create the root channel and call."""
+        self = self.sudo()
+        payload = dict(payload or {})
+        sid = payload.get('CallSid')
+        if not sid:
+            return self
+        channel_model = self.env['connect.channel']
+        channel = channel_model.search([('sid', '=', sid)], limit=1)
+        if not channel:
+            event_model = self.env['connect.call.event']
+            vals = event_model._channel_vals(payload, self, channel_model)
+            vals.update({
+                'sid': sid,
+                'sequence_number': int(payload.get('SequenceNumber') or 0),
+                'event_timestamp': event_model._parse_timestamp(payload)
+                    or fields.Datetime.now(),
+            })
+            channel = channel_model.with_context(
+                tracking_disable=True).create(vals)
+        return self._ensure_call_from_channel(channel)
+
+    @api.model
+    def _ensure_call_from_channel(self, channel):
+        """Create the aggregate for an already known root channel."""
+        self = self.sudo()
+        if channel.call:
+            return channel.call
+        if channel.parent_channel and channel.parent_channel.call:
+            channel.with_context(tracking_disable=True).write({
+                'call': channel.parent_channel.call.id,
+            })
+            return channel.parent_channel.call
+        if channel.parent_channel:
+            return self
+        if channel.technical_direction == 'outbound-api':
+            direction = 'outgoing'
+        elif channel.technical_direction == 'inbound' and channel.caller_pbx_user:
+            direction = 'outgoing'
+        elif channel.technical_direction == 'inbound':
+            direction = 'incoming'
         else:
-            logger.info(f"Call {self.id}: Clearing all webhook expectations")
-            del self.__class__._webhook_expectations[call_key]
+            direction = 'outgoing'
+        call = self.with_context(tracking_disable=True).create({
+            'partner': channel.partner.id,
+            'called': channel.called_number,
+            'caller': channel.caller_number,
+            'status': channel.status,
+            'caller_pbx_user': channel.caller_pbx_user.id,
+            'caller_user': channel.caller_user.id,
+            'direction': direction,
+            'call_type': channel.call_type or 'phone',
+            'call_pattern': (
+                'direct_call' if direction in ('outgoing', 'internal') else False
+            ),
+            'call_sid': channel.sid,
+        })
+        channel.with_context(tracking_disable=True).write({'call': call.id})
+        return call
+
+    def _after_call_projection(self, finalized, changed_fields):
+        """Extension hook invoked after an idempotent call projection."""
+        return True
 
     def write(self, vals: dict):
         if release.version_info[0] <= 15.0 and 'transfer_context' in vals:
@@ -785,7 +799,7 @@ class Call(models.Model):
         return records
 
     @api.model
-    def on_call_status(self, params):
+    def _on_call_status_legacy(self, params):
         self = self.sudo()
         # Create channel
         channel = self.env['connect.channel'].on_call_status(params)
@@ -958,26 +972,22 @@ class Call(models.Model):
         return channel.call.id
 
     @api.model
-    def on_vm_recording_status(self, params):
-        debug(self.sudo(), 'On recording status: %s' % json.dumps(params, indent=2))
-        channel = self.sudo().env['connect.channel'].search([('sid', '=', params['CallSid'])])
-        if channel and channel.call:
-            channel.call.write({
-                'voicemail_url': params.get('RecordingUrl'),
-                'voicemail_duration': int(params.get('RecordingDuration'))
-            })
+    def on_call_status(self, params, token=None):
+        """Compatibility entry point: enqueue lifecycle work."""
+        event = self.env['connect.call.event'].sudo().ingest(
+            'call_status', params, token=token)
+        return event.call_id.id if event.call_id else False
+
+    @api.model
+    def on_vm_recording_status(self, params, token=None):
+        self.env['connect.call.event'].sudo().ingest(
+            'voicemail_status', params, token=token)
         return True
 
     @api.model
-    def on_call_action(self, params):
-        debug(self, 'On call action: %s' % params)
-        # Check if this is a Dial action webhook with transfer completion data
-        if 'DialCallSid' in params and 'DialCallStatus' in params:
-            try:
-                self._process_transfer_completion(params)
-                logger.info(f"Successfully processed transfer completion")
-            except Exception as e:
-                logger.error(f"Failed to process transfer completion: {e}")
+    def on_call_action(self, params, token=None):
+        self.env['connect.call.event'].sudo().ingest(
+            'dial_action', params, token=token)
         return '<Response><Hangup/></Response>'
 
     def _process_transfer_completion(self, params):
@@ -1586,9 +1596,12 @@ class Call(models.Model):
                 debug(self, 'park_call: Redirected parent %s to park-%s' % (parent_call_sid, slot))
             except Exception as e:
                 logger.error('park_call: Failed to redirect parent call: %s', e)
+            else:
+                self._register_parked_call(parent_call_sid, slot, request)
         else:
             # No parent call — this is a direct call to *701, just enqueue it
             debug(self, 'park_call: No ParentCallSid, enqueueing CallSid=%s' % call_sid)
+            self._register_parked_call(call_sid, slot, request)
             response = VoiceResponse()
             response.enqueue('park-%s' % slot)
             return response
@@ -1599,17 +1612,236 @@ class Call(models.Model):
         return response
 
     @api.model
+    def _register_parked_call(self, parked_call_sid, slot, request):
+        """Remember which call is waiting in which parking slot.
+
+        Without this the retrieval leg has no way to know who is parked, so it
+        cannot present the original caller ID nor link the two calls together
+        in the call log.
+        """
+        call = self._get_call_by_sid(parked_call_sid)
+        if not call:
+            logger.warning('park_call: no call found for CallSid=%s, slot %s not tracked',
+                           parked_call_sid, slot)
+            return self.browse()
+        parked_by = self.env['connect.user'].sudo().get_user_by_uri(request.get('Caller'))[:1]
+        call.sudo().write({
+            'park_slot': slot,
+            'park_call_sid': parked_call_sid,
+            'parked_at': fields.Datetime.now(),
+            'parked_by_pbx_user': parked_by.id if parked_by else False,
+        })
+        call._message_log(body=Markup(_('Call parked in slot %(slot)s by %(user)s.')) % {
+            'slot': slot,
+            'user': parked_by.name if parked_by else _('an unknown user'),
+        })
+        debug(self, 'park_call: call %s parked in slot %s' % (call.id, slot))
+        return call
+
+    @api.model
+    def _get_call_by_sid(self, call_sid):
+        """Resolve the connect.call a Twilio CallSid belongs to."""
+        if not call_sid:
+            return self.browse()
+        channel = self.env['connect.channel'].sudo().search(
+            [('sid', '=', call_sid)], limit=1)
+        return channel.call.sudo() if channel.call else self.browse()
+
+    @api.model
+    def _get_parked_call(self, slot):
+        """The call to be retrieved from a slot.
+
+        Twilio dequeues the longest waiting caller, so when several calls share
+        a slot we must pick the oldest one to stay in sync with the queue.
+        """
+        if not slot:
+            return self.browse()
+        return self.sudo().search([
+            ('park_slot', '=', slot),
+            ('park_call_sid', '!=', False),
+        ], order='parked_at asc, id asc', limit=1)
+
+    @api.model
     def unpark_call(self, request, params):
         """Unpark (retrieve) a call from a parking slot.
 
         Called when someone dials extension 701-710.
         params['ExtenNumber'] contains the slot number.
+
+        The retrieving phone dialed the slot number, so its display shows the
+        slot (e.g. "702") and Twilio never re-signals the remote identity when
+        it bridges a queued caller into that established leg. To show the real
+        caller ID we hang up the retrieval leg and instead redirect the parked
+        call to dial the retriever back, presenting the original caller.
+        When the parked call is unknown (parked before this feature, tracking
+        lost, Twilio API error, ...) we fall back to the plain queue bridge.
         """
         slot = params.get('ExtenNumber', '')
         debug(self, 'unpark_call: Retrieving from slot %s' % slot)
-
+        retriever = self.env['connect.user'].sudo().get_user_by_uri(request.get('Caller'))[:1]
+        parked_call = self._get_parked_call(slot)
+        # Link the retrieval leg to the parked call so the call log keeps the
+        # customer's identity instead of showing a bare "exten -> slot" call.
+        self._link_park_retrieval_leg(request, slot, parked_call, retriever)
+        if parked_call and retriever:
+            if self._dial_back_parked_call(parked_call, retriever, slot, request):
+                # The parked call is now dialing the retriever, release the leg
+                # the retriever dialed the slot with.
+                response = VoiceResponse()
+                response.hangup()
+                return response
+        else:
+            debug(self, 'unpark_call: slot %s parked call %s retriever %s, using queue bridge' % (
+                slot, parked_call.id if parked_call else False,
+                retriever.username if retriever else False))
         response = VoiceResponse()
         dial = Dial(timeout=1)
         dial.queue('park-%s' % slot)
         response.append(dial)
+        return response
+
+    @api.model
+    def _link_park_retrieval_leg(self, request, slot, parked_call, retriever):
+        """Attach the "dialed the slot" call to the call being retrieved.
+
+        Retrieving a parked call creates its own <exten> -> <slot> call record.
+        Left alone it is an orphan with no partner, which is what made the call
+        log show "702" instead of the customer.
+        """
+        retrieval_call = self._get_call_by_sid(request.get('CallSid'))
+        if not retrieval_call or retrieval_call == parked_call:
+            return self.browse()
+        if parked_call:
+            vals = {'parent_call': parked_call.id}
+            if parked_call.partner and not retrieval_call.partner:
+                vals['partner'] = parked_call.partner.id
+            retrieval_call.sudo().write(vals)
+            parked_call.sudo()._message_log(body=Markup(_(
+                'Call retrieved from parking slot %(slot)s by %(user)s.')) % {
+                    'slot': slot,
+                    'user': retriever.name if retriever else _('an unknown user'),
+                })
+        retrieval_call.sudo()._message_log(body=Markup(_(
+            'Retrieval of the call parked in slot %(slot)s.')) % {'slot': slot})
+        return retrieval_call
+
+    @api.model
+    def _dial_back_parked_call(self, parked_call, retriever, slot, request):
+        """Take the parked call out of the queue and dial the retriever back.
+
+        Returns True when the redirect was accepted by Twilio, False to let the
+        caller fall back to the plain queue bridge.
+        """
+        # Serialize concurrent retrievals of the same slot: whoever gets the row
+        # lock first takes the call, the other one falls back to the queue.
+        parked_call.flush_recordset(['park_slot'])
+        self.env.cr.execute(
+            'SELECT park_slot FROM connect_call WHERE id = %s FOR UPDATE',
+            (parked_call.id,))
+        row = self.env.cr.fetchone()
+        if not row or not row[0]:
+            debug(self, 'unpark_call: call %s already retrieved' % parked_call.id)
+            return False
+        caller_uri = request.get('Caller') or ''
+        twiml = self._build_park_retrieval_twiml(
+            parked_call, retriever, slot, from_client=caller_uri.startswith('client:'))
+        if twiml is None:
+            return False
+        try:
+            client = self.env['connect.settings'].get_client()
+            client.calls(parked_call.park_call_sid).update(twiml=str(twiml))
+        except Exception as e:
+            logger.error('unpark_call: failed to redirect parked call %s: %s',
+                         parked_call.park_call_sid, e)
+            return False
+        debug(self, 'unpark_call: redirected parked call %s to %s' % (
+            parked_call.id, retriever.username))
+        # Keep park_call_sid: the retrieval Dial action re-parks the caller when
+        # the retriever does not answer.
+        parked_call.sudo().write({'park_slot': False})
+        return True
+
+    @api.model
+    def _build_park_retrieval_twiml(self, parked_call, retriever, slot, from_client=False):
+        """TwiML making the parked call ring the retriever with the real caller ID.
+
+        The retriever is called back on the device they retrieved from, so a
+        user with both a SIP phone and a web phone does not get both ringing.
+        Returns None when the retriever has no reachable endpoint.
+        """
+        caller_id = parked_call.caller
+        if not caller_id:
+            logger.warning('unpark_call: call %s has no caller number', parked_call.id)
+            return None
+        use_client = retriever.client_enabled and (from_client or not retriever.sip_enabled)
+        if not use_client and not retriever.sip_enabled:
+            logger.warning('unpark_call: user %s has no enabled endpoint', retriever.username)
+            return None
+        settings = self.env['connect.settings'].sudo()
+        api_url = settings.get_param('api_url')
+        edge = settings.get_param('twilio_edge')
+        status_url = urljoin(api_url, 'twilio/webhook/callstatus#e={}'.format(edge))
+        record_status_url = urljoin(api_url, 'twilio/webhook/recordingstatus#e={}'.format(edge))
+        refer_url = urljoin(api_url, 'twilio/webhook/sip_refer#e={}'.format(edge))
+        action_url = urljoin(api_url, 'twilio/webhook/park_retrieve/{}/{}#e={}'.format(
+            parked_call.id, slot, edge))
+        dial_kwargs = {
+            'timeout': (retriever.client_ring_timeout if use_client else retriever.sip_ring_timeout) or 30,
+            'callerId': caller_id,
+            'action': action_url,
+        }
+        if not use_client:
+            dial_kwargs['referUrl'] = refer_url
+        if retriever.record_calls and not parked_call.disable_recording:
+            dial_kwargs.update({
+                'record': 'record-from-answer-dual',
+                'recordingStatusCallback': record_status_url,
+            })
+        dial = Dial(**dial_kwargs)
+        if use_client:
+            client = Client(
+                statusCallbackEvent='initiated answered completed',
+                statusCallback=status_url)
+            client.identity(retriever.get_client_identity())
+            client.parameter(
+                name='CallerName',
+                value=parked_call.partner.name if parked_call.partner else caller_id)
+            client.parameter(
+                name='Partner',
+                value=parked_call.partner.id if parked_call.partner else False)
+            dial.append(client)
+        else:
+            dial.sip(
+                'sip:{}{}'.format(
+                    retriever.uri,
+                    ';secure=true' if retriever.domain.secure_media else ''),
+                statusCallbackEvent='initiated answered completed',
+                statusCallback=status_url)
+        response = VoiceResponse()
+        response.append(dial)
+        debug(self, 'unpark_call: retrieval TwiML for slot %s: %s' % (slot, str(response)))
+        return response
+
+    @api.model
+    def on_park_retrieve_action(self, call_id, slot, params):
+        """Dial action of the park retrieval leg.
+
+        The parked caller was taken out of the queue to ring the retriever. If
+        that call was not answered the caller must go back to their slot rather
+        than be dropped.
+        """
+        call = self.sudo().browse(call_id).exists()
+        dial_status = params.get('DialCallStatus')
+        debug(self, 'on_park_retrieve_action: call %s slot %s status %s' % (
+            call_id, slot, dial_status))
+        response = VoiceResponse()
+        if dial_status == 'completed' or not slot:
+            if call:
+                call.write({'park_slot': False, 'park_call_sid': False})
+            response.hangup()
+            return response
+        # Not answered: put the caller back into the parking slot.
+        if call:
+            call.write({'park_slot': slot, 'parked_at': fields.Datetime.now()})
+        response.enqueue('park-%s' % slot)
         return response

--- a/connect/models/call_attempt.py
+++ b/connect/models/call_attempt.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+
+from odoo import api, fields, models
+
+
+class CallAttempt(models.Model):
+    _name = "connect.call.attempt"
+    _description = "Call Runtime Attempt"
+    _order = "id desc"
+    _rec_name = "parent_sid"
+
+    kind = fields.Selection(
+        [
+            ("direct_call", "Direct Call"),
+            ("ring_group", "Ring Group"),
+            ("transfer", "Transfer"),
+            ("external_leg", "External Leg"),
+            ("external_termination", "External Termination"),
+        ],
+        required=True,
+        index=True,
+    )
+    call_id = fields.Many2one(
+        "connect.call", required=True, ondelete="cascade", index=True
+    )
+    parent_sid = fields.Char(index=True)
+    expected_count = fields.Integer(default=1, required=True)
+    target_user_id = fields.Many2one("res.users", ondelete="set null", index=True)
+    dial_call_sid = fields.Char(index=True)
+    external_sid = fields.Char(index=True)
+    state = fields.Selection(
+        [
+            ("pending", "Pending"),
+            ("resolved", "Resolved"),
+            ("expired", "Expired"),
+        ],
+        default="pending",
+        required=True,
+        index=True,
+    )
+    expires_at = fields.Datetime(required=True, index=True)
+    resolved_at = fields.Datetime(index=True)
+    context = fields.Json()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        default_expiry = fields.Datetime.now() + timedelta(hours=1)
+        for vals in vals_list:
+            vals.setdefault("expires_at", default_expiry)
+        return super().create(vals_list)
+
+    def mark_resolved(self):
+        pending = self.filtered(lambda attempt: attempt.state == "pending")
+        if pending:
+            pending.write(
+                {
+                    "state": "resolved",
+                    "resolved_at": fields.Datetime.now(),
+                }
+            )
+
+    @api.model
+    def vacuum(self):
+        now = fields.Datetime.now()
+        expired = self.search(
+            [("state", "=", "pending"), ("expires_at", "<=", now)]
+        )
+        if expired:
+            expired.write({"state": "expired", "resolved_at": now})
+
+        settings = self.env["connect.settings"].sudo()
+        delete_immediately = settings.get_param("delete_processed_call_events")
+        terminal = self.search(
+            [
+                ("state", "in", ["resolved", "expired"]),
+                ("resolved_at", "<=", now - timedelta(hours=1)),
+            ]
+        )
+        if delete_immediately:
+            terminal |= self.search(
+                [("state", "=", "resolved")]
+            )
+        if terminal:
+            terminal.unlink()

--- a/connect/models/call_event.py
+++ b/connect/models/call_event.py
@@ -1,0 +1,1090 @@
+# -*- coding: utf-8 -*-
+
+import hashlib
+import json
+import logging
+from collections import defaultdict
+from datetime import timedelta, timezone
+
+from dateutil.parser import parse as parse_datetime
+
+from odoo import SUPERUSER_ID, api, fields, models
+from odoo.modules.registry import Registry
+
+
+logger = logging.getLogger(__name__)
+
+CALL_END_STATUSES = {"completed", "busy", "failed", "no-answer", "canceled"}
+PROJECTOR_LOCK_CLASS = 0x636E6576  # "cnev"
+
+
+class PendingProjection(Exception):
+    """The event references a leg which has not arrived yet."""
+
+
+class CallEventDedup(models.Model):
+    _name = "connect.call.event.dedup"
+    _description = "Call Event Deduplication Tombstone"
+    _order = "id desc"
+
+    dedup_key = fields.Char(required=True, readonly=True, index=True)
+    expires_at = fields.Datetime(required=True, readonly=True, index=True)
+
+    _dedup_key_unique = models.Constraint(
+        "UNIQUE(dedup_key)", "The call event tombstone key must be unique."
+    )
+
+
+class CallEvent(models.Model):
+    _name = "connect.call.event"
+    _description = "Twilio Call Event"
+    _order = "id desc"
+    _rec_name = "dedup_key"
+
+    event_type = fields.Selection(
+        [
+            ("call_status", "Call Status"),
+            ("dial_action", "Dial Action"),
+            ("voicemail_status", "Voicemail Status"),
+        ],
+        required=True,
+        index=True,
+    )
+    dedup_key = fields.Char(required=True, readonly=True, index=True)
+    idempotency_token = fields.Char(readonly=True, index=True)
+    call_sid = fields.Char(readonly=True, index=True)
+    parent_call_sid = fields.Char(readonly=True, index=True)
+    root_call_sid = fields.Char(readonly=True, index=True)
+    sequence_number = fields.Integer(readonly=True, index=True)
+    event_timestamp = fields.Datetime(readonly=True, index=True)
+    payload = fields.Json(required=True, readonly=True)
+    state = fields.Selection(
+        [
+            ("pending", "Pending"),
+            ("processing", "Processing"),
+            ("done", "Done"),
+            ("error", "Error"),
+        ],
+        default="pending",
+        required=True,
+        readonly=True,
+        index=True,
+    )
+    attempts = fields.Integer(default=0, readonly=True)
+    next_attempt_at = fields.Datetime(readonly=True, index=True)
+    processed_at = fields.Datetime(readonly=True)
+    error_message = fields.Text(readonly=True)
+    call_id = fields.Many2one(
+        "connect.call", readonly=True, ondelete="set null", index=True
+    )
+    channel_id = fields.Many2one(
+        "connect.channel", readonly=True, ondelete="set null", index=True
+    )
+    command_type = fields.Selection(
+        [("hangup_call", "Hang up external call")], readonly=True
+    )
+    command_payload = fields.Json(readonly=True)
+    command_state = fields.Selection(
+        [
+            ("pending", "Pending"),
+            ("done", "Done"),
+            ("error", "Error"),
+        ],
+        readonly=True,
+        index=True,
+    )
+    command_attempts = fields.Integer(default=0, readonly=True)
+
+    _dedup_key_unique = models.Constraint(
+        "UNIQUE(dedup_key)", "The Twilio event deduplication key must be unique."
+    )
+
+    def init(self):
+        self.env.cr.execute(
+            """
+            CREATE INDEX IF NOT EXISTS connect_call_event_queue_idx
+                ON connect_call_event (state, next_attempt_at, id)
+            """
+        )
+        self.env.cr.execute(
+            """
+            CREATE INDEX IF NOT EXISTS connect_call_event_aggregate_idx
+                ON connect_call_event (root_call_sid, id)
+            """
+        )
+        self.env.cr.execute(
+            """
+            CREATE INDEX IF NOT EXISTS connect_call_event_leg_sequence_idx
+                ON connect_call_event (call_sid, sequence_number, id)
+            """
+        )
+
+    @api.model
+    def _parse_timestamp(self, payload):
+        value = payload.get("Timestamp") or payload.get("EventTimestamp")
+        if not value:
+            return False
+        try:
+            parsed = parse_datetime(value)
+            if parsed.tzinfo:
+                parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed
+        except (TypeError, ValueError, OverflowError):
+            logger.warning("Cannot parse Twilio event timestamp %r", value)
+            return False
+
+    @api.model
+    def _dedup_key(self, event_type, payload, token=None):
+        if token:
+            return "%s:token:%s" % (event_type, token)
+        normalized = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+        digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+        return "%s:payload:%s" % (event_type, digest)
+
+    @staticmethod
+    def _has_sequence(event):
+        return event.payload.get("SequenceNumber") not in (None, "")
+
+    @api.model
+    def ingest(self, event_type, payload, token=None):
+        """Atomically append an event without reading or updating connect.call."""
+        if event_type not in dict(self._fields["event_type"].selection):
+            raise ValueError("Unsupported call event type %r" % event_type)
+        payload = dict(payload or {})
+        call_sid = payload.get("CallSid") or payload.get("DialCallSid")
+        parent_sid = payload.get("ParentCallSid")
+        root_sid = parent_sid or payload.get("CallSid") or call_sid
+        sequence = payload.get("SequenceNumber")
+        try:
+            sequence = int(sequence) if sequence not in (None, "") else None
+        except (TypeError, ValueError):
+            sequence = None
+        event_timestamp = self._parse_timestamp(payload) or None
+        dedup_key = self._dedup_key(event_type, payload, token)
+        now = fields.Datetime.now()
+        lock_key = int.from_bytes(
+            hashlib.sha256(dedup_key.encode("utf-8")).digest()[:8],
+            byteorder="big",
+            signed=True,
+        )
+
+        # PostgreSQL can raise a serialization failure for two concurrent
+        # INSERT .. ON CONFLICT statements under Odoo's REPEATABLE READ
+        # isolation. Serialize only the identical dedup key, then check through
+        # a fresh cursor so a row committed after this request's snapshot is
+        # still visible.
+        self.env.cr.execute("SELECT pg_advisory_xact_lock(%s)", (lock_key,))
+        self.env.cr.execute(
+            "SELECT 1 FROM connect_call_event_dedup WHERE dedup_key = %s",
+            (dedup_key,),
+        )
+        if self.env.cr.fetchone():
+            return self.search([("dedup_key", "=", dedup_key)], limit=1)
+        with Registry(self.env.cr.dbname).cursor() as check_cr:
+            check_cr.execute(
+                "SELECT 1 FROM connect_call_event_dedup WHERE dedup_key = %s",
+                (dedup_key,),
+            )
+            if check_cr.fetchone():
+                return self
+
+        self.env.cr.execute(
+            """
+            INSERT INTO connect_call_event_dedup (
+                dedup_key, expires_at,
+                create_uid, create_date, write_uid, write_date
+            )
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (dedup_key) DO NOTHING
+            """,
+            (
+                dedup_key,
+                now + timedelta(days=1),
+                self.env.uid,
+                now,
+                self.env.uid,
+                now,
+            ),
+        )
+        self.env.cr.execute(
+            """
+            INSERT INTO connect_call_event (
+                event_type, dedup_key, idempotency_token,
+                call_sid, parent_call_sid, root_call_sid,
+                sequence_number, event_timestamp, payload, state, attempts,
+                create_uid, create_date, write_uid, write_date
+            )
+            VALUES (
+                %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb,
+                'pending', 0, %s, %s, %s, %s
+            )
+            ON CONFLICT (dedup_key) DO NOTHING
+            RETURNING id
+            """,
+            (
+                event_type,
+                dedup_key,
+                token,
+                call_sid,
+                parent_sid,
+                root_sid,
+                sequence,
+                event_timestamp,
+                json.dumps(payload),
+                self.env.uid,
+                now,
+                self.env.uid,
+                now,
+            ),
+        )
+        row = self.env.cr.fetchone()
+        event = self.browse(row[0]) if row else self.search(
+            [("dedup_key", "=", dedup_key)], limit=1
+        )
+        if row:
+            self._trigger_projector_after_commit()
+        return event
+
+    @api.model
+    def _trigger_projector_after_commit(self):
+        db_name = self.env.cr.dbname
+
+        def trigger():
+            try:
+                with Registry(db_name).cursor() as cr:
+                    env = api.Environment(cr, SUPERUSER_ID, {})
+                    env.ref("connect.process_call_events")._trigger()
+                    cr.commit()
+            except Exception:
+                logger.exception("Could not trigger the call event projector")
+
+        self.env.cr.postcommit.add(trigger)
+
+    @api.model
+    def process_pending_events(self, limit=200):
+        """Project pending inbox rows in one serialized cron transaction."""
+        self = self.sudo()
+        self.env.cr.execute(
+            "SELECT pg_try_advisory_xact_lock(%s, 0)", (PROJECTOR_LOCK_CLASS,)
+        )
+        if not self.env.cr.fetchone()[0]:
+            return 0
+
+        now = fields.Datetime.now()
+        events = self.search(
+            [
+                ("state", "=", "pending"),
+                "|",
+                ("next_attempt_at", "=", False),
+                ("next_attempt_at", "<=", now),
+            ],
+            order="id",
+            limit=limit,
+        )
+        event_sids = set(
+            events.mapped("call_sid") + events.mapped("parent_call_sid")
+        )
+        channels = self.env["connect.channel"].search(
+            [("sid", "in", list(event_sids))]
+        )
+        call_by_sid = {
+            channel.sid: channel.call.id
+            for channel in channels
+            if channel.sid and channel.call
+        }
+        parent_by_sid = {
+            channel.sid: channel.parent_sid
+            for channel in channels
+            if channel.sid and channel.parent_sid
+        }
+        parent_by_sid.update(
+            {
+                event.call_sid: event.parent_call_sid
+                for event in events
+                if event.call_sid and event.parent_call_sid
+            }
+        )
+
+        def aggregate_sid(event):
+            sid = event.call_sid or event.root_call_sid
+            seen = set()
+            while sid and parent_by_sid.get(sid) and sid not in seen:
+                seen.add(sid)
+                sid = parent_by_sid[sid]
+            return sid or event.root_call_sid or str(event.id)
+
+        groups = defaultdict(lambda: self.browse())
+        for event in events:
+            call_id = event.call_id.id or call_by_sid.get(event.call_sid)
+            call_id = call_id or call_by_sid.get(event.parent_call_sid)
+            root_sid = aggregate_sid(event)
+            key = "call:%s" % call_id if call_id else "sid:%s" % root_sid
+            groups[key] |= event
+            if root_sid and event.root_call_sid != root_sid:
+                event.root_call_sid = root_sid
+
+        processed = 0
+        commands_scheduled = bool(
+            self.search_count(
+                [("command_state", "in", ["pending", "error"])], limit=1
+            )
+        )
+        for group in groups.values():
+            for event in group:
+                event.write(
+                    {
+                        "state": "processing",
+                        "attempts": event.attempts + 1,
+                        "error_message": False,
+                    }
+                )
+            try:
+                with self.env.cr.savepoint():
+                    self._project_group(group)
+            except PendingProjection as exc:
+                self._defer_or_fail(group, str(exc))
+            except Exception as exc:
+                logger.exception("Call event projection failed for %s", group.ids)
+                self._defer_or_fail(group, str(exc))
+            else:
+                group.write(
+                    {
+                        "state": "done",
+                        "processed_at": fields.Datetime.now(),
+                        "next_attempt_at": False,
+                        "error_message": False,
+                    }
+                )
+                processed += len(group)
+                commands_scheduled |= any(group.mapped("command_state"))
+
+        self._vacuum()
+        if commands_scheduled:
+            self._run_commands_after_commit()
+        return processed
+
+    def _defer_or_fail(self, events, message):
+        now = fields.Datetime.now()
+        oldest = min(events.mapped("create_date"))
+        terminal = oldest <= now - timedelta(hours=1)
+        retry_at = False if terminal else now + timedelta(seconds=5)
+        events.write(
+            {
+                "state": "error" if terminal else "pending",
+                "next_attempt_at": retry_at,
+                "error_message": message[:4000],
+            }
+        )
+        if retry_at:
+            self.env.ref("connect.process_call_events")._trigger(at=retry_at)
+
+    def _project_group(self, events):
+        root_sid = events[0].root_call_sid
+        call = self._resolve_group_call(events, root_sid)
+        call_vals = {}
+
+        ordered = events.sorted(
+            key=lambda event: (
+                event.event_type != "call_status",
+                bool(event.parent_call_sid),
+                event.sequence_number
+                if self._has_sequence(event)
+                else 2**31,
+                event.event_timestamp or event.create_date,
+                event.id,
+            )
+        )
+        for event in ordered:
+            if event.event_type == "call_status":
+                channel = self._apply_call_status_event(event, call)
+                call = channel.call or call
+            elif event.event_type == "dial_action":
+                channel = self._apply_dial_action_event(event, call)
+                call = channel.call or call
+            else:
+                channel = self._resolve_event_channel(event, call)
+                call_vals.update(
+                    {
+                        "voicemail_url": event.payload.get("RecordingUrl"),
+                        "voicemail_duration": int(
+                            event.payload.get("RecordingDuration") or 0
+                        ),
+                    }
+                )
+            event.write(
+                {
+                    "call_id": call.id if call else False,
+                    "channel_id": channel.id if channel else False,
+                }
+            )
+
+        if not call:
+            raise PendingProjection("Call has not been created yet")
+        self._refresh_attempts(call, ordered)
+        self._project_call(call, ordered, call_vals)
+
+    def _resolve_group_call(self, events, root_sid):
+        calls = events.mapped("call_id").exists()
+        if calls:
+            return calls[0]
+        sids = set(events.mapped("call_sid") + events.mapped("parent_call_sid"))
+        channels = self.env["connect.channel"].search([("sid", "in", list(sids))])
+        calls = channels.mapped("call")
+        if calls:
+            return calls[0]
+        root_channel = self.env["connect.channel"].search(
+            [("sid", "=", root_sid)], limit=1
+        )
+        if root_channel:
+            return self.env["connect.call"]._ensure_call_from_channel(root_channel)
+        root_events = events.filtered(
+            lambda event: event.event_type == "call_status"
+            and not event.parent_call_sid
+        )
+        if root_events:
+            return self.env["connect.call"].ensure_initial_call(root_events[0].payload)
+        return self.env["connect.call"]
+
+    def _resolve_event_channel(self, event, call):
+        channel = self.env["connect.channel"].search(
+            [("sid", "=", event.call_sid)], limit=1
+        )
+        if not channel or (not channel.call and not call):
+            raise PendingProjection("Channel %s has not arrived yet" % event.call_sid)
+        if not channel.call and call:
+            channel.write({"call": call.id})
+        return channel
+
+    def _is_stale(self, channel, event):
+        if not channel:
+            return False
+        if self._has_sequence(event):
+            current_sequence = channel.sequence_number
+            if event.sequence_number < current_sequence:
+                return True
+            if event.sequence_number > (current_sequence or 0):
+                return False
+        current_time = channel.event_timestamp
+        event_time = event.event_timestamp or event.create_date
+        if current_time and event_time < current_time:
+            return True
+        if current_time and event_time == current_time:
+            return event.id <= (channel.last_event_id or 0)
+        return False
+
+    def _apply_call_status_event(self, event, call):
+        payload = event.payload
+        sid = payload.get("CallSid")
+        if not sid:
+            raise ValueError("Call status event has no CallSid")
+        channel_model = self.env["connect.channel"]
+        channel = channel_model.search([("sid", "=", sid)], limit=1)
+        if self._is_stale(channel, event):
+            return channel
+
+        parent = channel_model
+        parent_sid = payload.get("ParentCallSid")
+        if parent_sid:
+            parent = channel_model.search([("sid", "=", parent_sid)], limit=1)
+            if not parent:
+                raise PendingProjection("Parent channel %s has not arrived yet" % parent_sid)
+            call = parent.call or call
+        if not call and channel and channel.call:
+            call = channel.call
+        if not call and not parent_sid:
+            call = self.env["connect.call"].ensure_initial_call(payload)
+            channel = channel_model.search([("sid", "=", sid)], limit=1)
+        if not call:
+            raise PendingProjection("Call for channel %s has not arrived yet" % sid)
+
+        vals = self._channel_vals(payload, call, parent)
+        vals.update(
+            {
+                "call": call.id,
+                "sequence_number": event.sequence_number
+                if self._has_sequence(event)
+                else (channel.sequence_number if channel else 0),
+                "event_timestamp": event.event_timestamp or event.create_date,
+                "last_event_id": event.id,
+            }
+        )
+        if channel:
+            channel.with_context(tracking_disable=True).write(vals)
+        else:
+            vals["sid"] = sid
+            channel = channel_model.with_context(tracking_disable=True).create(vals)
+        self._prepare_external_command(event, call, channel)
+        return channel
+
+    def _channel_vals(self, payload, call, parent):
+        def strip_whatsapp(value):
+            if isinstance(value, str) and value.startswith("whatsapp:"):
+                return value.split(":", 1)[1]
+            return value
+
+        caller_raw = payload.get("Caller") or payload.get("From")
+        called_raw = payload.get("Called") or payload.get("To")
+        to_raw = payload.get("To")
+        caller = strip_whatsapp(caller_raw)
+        called = strip_whatsapp(called_raw)
+        to = strip_whatsapp(to_raw)
+        call_type = (
+            "whatsapp"
+            if any(
+                isinstance(value, str) and value.startswith("whatsapp:")
+                for value in (caller_raw, called_raw, to_raw)
+            )
+            else "phone"
+        )
+        vals = {
+            "technical_direction": payload.get("Direction"),
+            "status": payload.get("CallStatus"),
+            "duration": int(payload.get("CallDuration") or 0),
+            "call_type": call_type,
+        }
+        if caller:
+            vals["caller"] = caller
+        if called:
+            vals["called"] = called
+        if to:
+            vals["to"] = to
+        if payload.get("SipCallId"):
+            vals["sip_call_id"] = payload["SipCallId"]
+        if parent:
+            vals.update({"parent_channel": parent.id, "parent_sid": parent.sid})
+
+        caller_pbx = (
+            self.env["connect.user"].get_user_by_uri(caller_raw)
+            if caller_raw
+            else self.env["connect.user"]
+        )
+        called_pbx = (
+            self.env["connect.user"].get_user_by_uri(called_raw)
+            if called_raw
+            else self.env["connect.user"]
+        )
+        if caller_pbx:
+            vals.update(
+                {
+                    "caller_pbx_user": caller_pbx.id,
+                    "caller_user": caller_pbx.user.id,
+                }
+            )
+        if called_pbx:
+            vals.update(
+                {
+                    "called_pbx_user": called_pbx.id,
+                    "called_user": called_pbx.user.id,
+                }
+            )
+
+        partner = self.env["res.partner"]
+        if caller_pbx and called and called.startswith(("+", "sip:+")):
+            partner = self.env["res.partner"].get_partner_by_number(called)
+        elif called_pbx and caller and caller.startswith("+"):
+            partner = self.env["res.partner"].get_partner_by_number(caller)
+        elif payload.get("Direction") == "outbound-dial" and called:
+            partner = self.env["res.partner"].get_partner_by_number(called)
+        elif (
+            payload.get("Direction") == "inbound"
+            and called
+            and called.startswith("+")
+            and caller
+            and caller.startswith("+")
+        ):
+            partner = self.env["res.partner"].get_partner_by_number(caller)
+        if partner:
+            vals["partner"] = partner.id
+
+        if parent:
+            attempt = call.attempt_ids.filtered(
+                lambda item: item.state == "pending"
+                and (
+                    item.dial_call_sid == payload.get("CallSid")
+                    or (
+                        item.target_user_id
+                        and called_pbx
+                        and item.target_user_id == called_pbx.user
+                    )
+                )
+            )[:1]
+            if attempt:
+                vals["call_source"] = (
+                    "external_dial"
+                    if attempt.kind == "external_leg"
+                    else attempt.kind
+                )
+            elif call.call_pattern == "ring_group":
+                vals["call_source"] = "ring_group"
+            elif called_raw and called_raw.startswith(("sip:", "client:")):
+                vals["call_source"] = "direct_call"
+            else:
+                vals["call_source"] = "external_dial"
+        return vals
+
+    def _apply_dial_action_event(self, event, call):
+        payload = event.payload
+        original = self.env["connect.channel"].search(
+            [("sid", "=", payload.get("CallSid"))], limit=1
+        )
+        call = original.call or call
+        if not original or not call:
+            raise PendingProjection(
+                "Dial action parent %s has not arrived yet" % payload.get("CallSid")
+            )
+        dial_sid = payload.get("DialCallSid")
+        if not dial_sid:
+            return original
+        channel = self.env["connect.channel"].search(
+            [("sid", "=", dial_sid)], limit=1
+        )
+        if payload.get("ConnectActionModel") not in (None, "connect.call"):
+            if payload.get("DialCallStatus") in CALL_END_STATUSES:
+                action_model = payload.get("ConnectActionModel")
+                kinds = (
+                    ("direct_call",)
+                    if action_model == "connect.user"
+                    else ("direct_call", "ring_group")
+                )
+                call.attempt_ids.filtered(
+                    lambda item: item.state == "pending"
+                    and item.kind in kinds
+                ).mark_resolved()
+            # Leg status callbacks carry the addressing information needed to
+            # create and sequence a complete channel. A generic Dial action
+            # must neither manufacture a transfer leg nor regress its status.
+            return channel or original
+
+        attempt = call.attempt_ids.filtered(
+            lambda item: item.dial_call_sid in (dial_sid, payload.get("CallSid"))
+            and item.kind == "transfer"
+        )[:1]
+        target_user = attempt.target_user_id if attempt else call.transferred_users[-1:]
+        pbx_user = (
+            self.env["connect.user"].search(
+                [("user", "=", target_user.id)], limit=1
+            )
+            if target_user
+            else self.env["connect.user"]
+        )
+        vals = {
+            "call": call.id,
+            "parent_channel": original.id,
+            "parent_sid": original.sid,
+            "technical_direction": "outbound-dial",
+            "status": payload.get("DialCallStatus"),
+            "duration": int(payload.get("DialCallDuration") or 0),
+            "call_source": "transfer",
+            "last_event_id": event.id,
+            "event_timestamp": event.event_timestamp or event.create_date,
+        }
+        if pbx_user:
+            vals.update(
+                {
+                    "called_pbx_user": pbx_user.id,
+                    "called_user": target_user.id,
+                    "called": pbx_user.uri,
+                    "caller": original.caller,
+                }
+            )
+        if channel:
+            channel.with_context(tracking_disable=True).write(vals)
+        else:
+            vals["sid"] = dial_sid
+            channel = self.env["connect.channel"].with_context(
+                tracking_disable=True
+            ).create(vals)
+        if attempt and channel.status in CALL_END_STATUSES:
+            attempt.mark_resolved()
+        if (
+            attempt
+            and channel.status == "completed"
+            and not event.command_state
+        ):
+            external_leg = call.attempt_ids.filtered(
+                lambda item: item.kind == "external_leg"
+                and item.external_sid
+            ).sorted("id")[-1:]
+            if external_leg:
+                termination = call.attempt_ids.filtered(
+                    lambda item: item.kind == "external_termination"
+                    and item.state == "pending"
+                    and item.dial_call_sid == channel.sid
+                )[:1]
+                if not termination:
+                    self.env["connect.call.attempt"].create(
+                        {
+                            "kind": "external_termination",
+                            "call_id": call.id,
+                            "parent_sid": original.sid,
+                            "dial_call_sid": channel.sid,
+                            "external_sid": external_leg.external_sid,
+                        }
+                    )
+                self._prepare_external_command(event, call, channel)
+        return channel
+
+    def _refresh_attempts(self, call, events):
+        now = fields.Datetime.now()
+        for attempt in call.attempt_ids.filtered(lambda item: item.state == "pending"):
+            if attempt.expires_at <= now:
+                attempt.write({"state": "expired", "resolved_at": now})
+                continue
+            if attempt.kind == "external_leg":
+                continue
+            channels = call.channels
+            if attempt.dial_call_sid:
+                channels = channels.filtered(
+                    lambda channel: channel.sid == attempt.dial_call_sid
+                )
+            elif attempt.target_user_id:
+                channels = channels.filtered(
+                    lambda channel: channel.called_user == attempt.target_user_id
+                )
+            elif attempt.kind in ("ring_group", "direct_call", "transfer"):
+                channels = channels.filtered(
+                    lambda channel: channel.call_source == attempt.kind
+                )
+            terminal = channels.filtered(
+                lambda channel: channel.status in CALL_END_STATUSES
+            )
+            if len(terminal) >= attempt.expected_count:
+                attempt.mark_resolved()
+
+    def _project_call(self, call, events, extra_vals):
+        channels = call.channels
+        roots = channels.filtered(lambda channel: not channel.parent_channel)
+        root = roots.filtered(lambda channel: channel.sid == call.call_sid)[:1]
+        root = root or roots[:1]
+        if not root:
+            raise PendingProjection("Call %s has no root channel" % call.id)
+
+        direction = call.direction
+        if root.technical_direction == "outbound-api" or (
+            root.technical_direction == "inbound" and root.caller_pbx_user
+        ):
+            direction = "outgoing"
+        elif root.technical_direction == "inbound":
+            direction = "incoming"
+        if any(
+            channel.parent_channel
+            and (
+                (
+                    channel.caller_pbx_user
+                    and channel.parent_channel.called_pbx_user
+                )
+                or (
+                    channel.called_pbx_user
+                    and channel.parent_channel.caller_pbx_user
+                )
+            )
+            for channel in channels
+        ) and not call.transferred_users:
+            direction = "internal"
+
+        transferred_ids = set(call.transferred_users.ids)
+        transferred_ids.update(
+            call.attempt_ids.filtered(
+                lambda attempt: attempt.kind == "transfer" and attempt.target_user_id
+            ).mapped("target_user_id").ids
+        )
+        user_channels = channels.filtered(
+            lambda channel: channel.called_pbx_user
+            and channel.called_pbx_user.user
+        )
+        called_user_ids = set(user_channels.mapped("called_user").ids)
+        called_pbx_ids = set(user_channels.mapped("called_pbx_user").ids)
+        completed = user_channels.filtered(
+            lambda channel: channel.status == "completed"
+        )
+        initial_completed = completed.filtered(
+            lambda channel: channel.called_user.id not in transferred_ids
+        )
+        answered_channel = (initial_completed or completed).sorted("id")[:1]
+        transfer_completed = completed.filtered(
+            lambda channel: channel.called_user.id in transferred_ids
+        ).sorted("id")
+
+        answered_user = answered_channel.called_user
+        answered_pbx = answered_channel.called_pbx_user
+        if transfer_completed:
+            completed_by = transfer_completed[-1].called_user
+        elif direction == "outgoing":
+            caller_channels = channels.filtered(
+                lambda channel: channel.caller_user
+            ).sorted("id")
+            completed_by = caller_channels[:1].caller_user
+        else:
+            completed_by = answered_user
+
+        ring_channels = channels.filtered(
+            lambda channel: channel.call_source == "ring_group"
+        )
+        if ring_channels:
+            pattern = "ring_group"
+        elif call.call_pattern:
+            pattern = call.call_pattern
+        elif direction in ("outgoing", "internal") or user_channels:
+            pattern = "direct_call"
+        else:
+            pattern = False
+
+        attempts_pending = call.attempt_ids.filtered(
+            lambda attempt: attempt.state == "pending"
+            and attempt.kind not in ("external_leg", "external_termination")
+        )
+        all_terminal = bool(channels) and all(
+            channel.status in CALL_END_STATUSES for channel in channels
+        )
+        finalized = (
+            root.status in CALL_END_STATUSES
+            and all_terminal
+            and not attempts_pending
+        )
+        statuses = set(channels.mapped("status"))
+        if finalized:
+            if direction == "outgoing" or answered_user:
+                status = "completed"
+            elif "failed" in statuses:
+                status = "failed"
+            elif "no-answer" in statuses:
+                status = "no-answer"
+            elif "busy" in statuses:
+                status = "busy"
+            else:
+                status = "no-answer"
+        elif "in-progress" in statuses:
+            status = "in-progress"
+        elif "ringing" in statuses:
+            status = "ringing"
+        else:
+            status = root.status
+
+        latest_event = events.sorted("id")[-1]
+        latest_error_event = events.filtered(
+            lambda event: event.payload.get("ErrorCode")
+            and event.payload.get("ErrorCode") != "32009"
+        ).sorted("id")
+        partner = channels.filtered("partner")[:1].partner
+        called = root.called_number
+        if root.technical_direction == "outbound-api":
+            outbound = channels.filtered(
+                lambda channel: channel.technical_direction == "outbound-dial"
+            )[:1]
+            called = outbound.called_number or called
+
+        vals = {
+            "partner": partner.id,
+            "called": called,
+            "caller": root.caller_number,
+            "status": status,
+            "duration": sum(channels.mapped("duration") or [0]),
+            "caller_pbx_user": root.caller_pbx_user.id,
+            "caller_user": root.caller_user.id,
+            "direction": direction,
+            "call_type": root.call_type or "phone",
+            "call_pattern": pattern,
+            "called_pbx_users": [(6, 0, sorted(called_pbx_ids))],
+            "called_users": [(6, 0, sorted(called_user_ids))],
+            "transferred_users": [(6, 0, sorted(transferred_ids))],
+            "answered_pbx_user": answered_pbx.id,
+            "answered_user": answered_user.id,
+            "completed_by_user": completed_by.id,
+            "call_sid": root.sid,
+            "projection_event_id": max(events.ids),
+        }
+        vals.update(extra_vals)
+        if latest_error_event:
+            payload = latest_error_event[-1].payload
+            vals.update(
+                {
+                    "has_error": True,
+                    "error_code": payload.get("ErrorCode"),
+                    "error_message": payload.get("ErrorMessage"),
+                }
+            )
+        notify_error = bool(
+            latest_error_event
+            and direction == "outgoing"
+            and not call.error_notification_done
+            and (root.caller_user or call.caller_user)
+        )
+        if notify_error:
+            vals["error_notification_done"] = True
+        first_finalization = finalized and not call.finalized_at
+        if finalized:
+            vals.update(
+                {
+                    "finalized_at": call.finalized_at or fields.Datetime.now(),
+                    "finalization_event_id": max(events.ids),
+                    "registration_done": True,
+                }
+            )
+            if (
+                first_finalization
+                and self.env["connect.settings"].sudo().get_param(
+                    "fetch_call_prices"
+                )
+            ):
+                vals["is_price_fetched"] = False
+
+        notify_ringing = (
+            direction == "incoming"
+            and not call.ring_notification_done
+            and any(
+                event.payload.get("CallStatus") == "initiated"
+                and (event.payload.get("To") or "").startswith("sip:")
+                for event in events
+            )
+        )
+        if notify_ringing:
+            vals["ring_notification_done"] = True
+        changed_fields = self._changed_fields(call, vals)
+        call.with_context(tracking_disable=True).write(vals)
+
+        if first_finalization:
+            call.register_call(root, latest_event.payload)
+        if notify_ringing:
+            root.connect_notify()
+        if notify_error:
+            error_payload = latest_error_event[-1].payload
+            message = error_payload.get("ErrorMessage") or ""
+            self.env["connect.settings"].connect_notify(
+                notify_uid=(root.caller_user or call.caller_user).id,
+                title="Call Error",
+                message=message,
+                warning=True,
+            )
+        call._after_call_projection(finalized, changed_fields)
+
+    def _changed_fields(self, call, vals):
+        changed = set()
+        for field_name, value in vals.items():
+            field = call._fields[field_name]
+            current = call[field_name]
+            if field.type == "many2many":
+                target = set(value[0][2]) if value else set()
+                if set(current.ids) != target:
+                    changed.add(field_name)
+            elif field.type == "many2one":
+                if current.id != (value or False):
+                    changed.add(field_name)
+            elif current != value:
+                changed.add(field_name)
+        return changed
+
+    def _prepare_external_command(self, event, call, channel):
+        if channel.status not in CALL_END_STATUSES:
+            return
+        attempts = call.attempt_ids.filtered(
+            lambda attempt: attempt.kind == "external_termination"
+            and attempt.state == "pending"
+            and attempt.dial_call_sid == channel.sid
+            and attempt.external_sid
+        )
+        if not attempts:
+            return
+        attempt = attempts[0]
+        event.write(
+            {
+                "command_type": "hangup_call",
+                "command_payload": {
+                    "call_sid": attempt.external_sid,
+                    "source_event_key": event.dedup_key,
+                },
+                "command_state": "pending",
+            }
+        )
+        attempt.mark_resolved()
+
+    @api.model
+    def _run_commands_after_commit(self):
+        db_name = self.env.cr.dbname
+
+        def run():
+            try:
+                with Registry(db_name).cursor() as cr:
+                    env = api.Environment(cr, SUPERUSER_ID, {})
+                    env["connect.call.event"]._execute_pending_commands()
+                    cr.commit()
+            except Exception:
+                logger.exception("Could not run call event post-commit commands")
+
+        self.env.cr.postcommit.add(run)
+
+    @api.model
+    def _execute_pending_commands(self):
+        cutoff = fields.Datetime.now() - timedelta(hours=1)
+        expired = self.sudo().search(
+            [
+                ("command_state", "in", ["pending", "error"]),
+                ("create_date", "<=", cutoff),
+            ]
+        )
+        if expired:
+            expired.write(
+                {
+                    "state": "error",
+                    "command_state": False,
+                    "error_message": "Post-commit command retry window expired",
+                }
+            )
+        events = self.sudo().search(
+            [
+                ("command_state", "in", ["pending", "error"]),
+                ("create_date", ">", cutoff),
+            ],
+            order="id",
+            limit=50,
+        )
+        for event in events:
+            try:
+                if event.command_type == "hangup_call":
+                    sid = (event.command_payload or {}).get("call_sid")
+                    self.env["connect.settings"].sudo().get_client().calls(sid).update(
+                        status="completed"
+                    )
+                event.write(
+                    {
+                        "command_state": "done",
+                        "command_attempts": event.command_attempts + 1,
+                        "error_message": False,
+                    }
+                )
+            except Exception as exc:
+                event.write(
+                    {
+                        "command_state": "error",
+                        "command_attempts": event.command_attempts + 1,
+                        "error_message": str(exc)[:4000],
+                    }
+                )
+        self._vacuum()
+
+    @api.model
+    def _vacuum(self):
+        now = fields.Datetime.now()
+        settings = self.env["connect.settings"].sudo()
+        delete_immediately = settings.get_param("delete_processed_call_events")
+        done_domain = [
+            ("state", "=", "done"),
+            "|",
+            ("command_state", "=", False),
+            ("command_state", "=", "done"),
+        ]
+        if not delete_immediately:
+            done_domain.append(("processed_at", "<=", now - timedelta(hours=1)))
+        done = self.search(done_domain)
+        errors = self.search(
+            [
+                ("state", "=", "error"),
+                ("write_date", "<=", now - timedelta(hours=1)),
+            ]
+        )
+        (done | errors).unlink()
+        self.env["connect.call.event.dedup"].sudo().search(
+            [("expires_at", "<=", now)]
+        ).unlink()
+        self.env["connect.call.attempt"].vacuum()

--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -136,6 +136,7 @@ class CallFlow(models.Model):
             self.get_prompt_message(response)
         # Add ringall users
         if self.ring_users:
+            expected_leg_count = 0
             callerId = request.get('Caller')
             # Hack to enable testing callflow from SIP or Client.
             if callerId.startswith('sip:') or callerId.startswith('client:'):
@@ -180,6 +181,7 @@ class CallFlow(models.Model):
                         dial.sip('sip:{}'.format(user.uri),
                                 statusCallbackEvent='answered completed',
                                 statusCallback=status_url)
+                        expected_leg_count += 1
                     else:
                         client = Client(
                             statusCallbackEvent='answered completed',
@@ -189,6 +191,22 @@ class CallFlow(models.Model):
                             client.parameter(name='CallerName', value=caller_name)
                         client.parameter(name='Partner', value=caller_partner_id)
                         dial.append(client)
+                        expected_leg_count += 1
+            root_channel = self.env['connect.channel'].sudo().search(
+                [('sid', '=', request.get('CallSid'))], limit=1)
+            if root_channel.call and expected_leg_count:
+                call = root_channel.call
+                if call.call_pattern != 'ring_group':
+                    call.call_pattern = 'ring_group'
+                pending = call.attempt_ids.filtered(
+                    lambda attempt: attempt.kind == 'ring_group'
+                    and attempt.state == 'pending')[:1]
+                if pending:
+                    pending.write({'expected_count': expected_leg_count})
+                else:
+                    call._set_webhook_expectation('ring_group', {
+                        'expected_count': expected_leg_count,
+                    })
             response.append(dial)
         else:
             # No ring users set, just send to voicemail if enabled.

--- a/connect/models/channel.py
+++ b/connect/models/channel.py
@@ -5,6 +5,7 @@ import logging
 import re
 from urllib.parse import urljoin
 from odoo import fields, models, api, release
+from odoo.tools import sql
 from .settings import debug
 
 CALL_END_STATUSES = ['completed', 'busy', 'failed', 'no-answer', 'canceled']
@@ -57,10 +58,138 @@ class Channel(models.Model):
     sip_call_id = fields.Char('SIP Call-ID', index=True)
     # Webhook sequence tracking for duplicate filtering
     sequence_number = fields.Integer(string='Sequence Number', default=0, help='Twilio webhook sequence number for duplicate filtering')
+    event_timestamp = fields.Datetime(
+        string='Last Event Timestamp', readonly=True, index=True)
+    last_event_id = fields.Integer(
+        string='Last Event ID', readonly=True, index=True)
     pbx_group_user_ids = fields.Many2many(
         'res.users', 'connect_channel_pbx_group_users_rel',
         string='PBX Group Users',
         compute='_compute_pbx_group_user_ids', store=True)
+
+    _sid_unique = models.Constraint(
+        'UNIQUE(sid)', 'A Twilio Call SID can only have one channel.')
+
+    def _auto_init(self):
+        # _sid_unique is applied at the very end of _auto_init, so leftover
+        # duplicates have to be merged before that: Postgres would refuse the
+        # index, odoo.schema would log an error, and the upgrade would still
+        # succeed with the constraint silently missing. Doing this here rather
+        # than in a migration script keeps it independent of the module
+        # version, which is what a database has to cross for a migration
+        # folder to be picked up at all.
+        self._merge_duplicate_sids()
+        return super()._auto_init()
+
+    def _merge_duplicate_sids(self):
+        """Keep one channel per Twilio SID, repointing everything that
+        referenced the discarded rows."""
+        cr = self.env.cr
+        if not sql.table_exists(cr, self._table):
+            return
+        has_parent = sql.column_exists(cr, self._table, 'parent_channel')
+        has_parent_sid = sql.column_exists(cr, self._table, 'parent_sid')
+        has_sequence = sql.column_exists(cr, self._table, 'sequence_number')
+        # Prefer the row carrying the most information; the columns are probed
+        # because this also runs on databases predating some of them.
+        richness = [
+            column for column in (
+                'call', 'partner', 'caller_pbx_user', 'called_pbx_user',
+                'caller', 'called', 'duration',
+            )
+            if sql.column_exists(cr, self._table, column)
+        ]
+        score = ' + '.join('(%s IS NOT NULL)::integer' % c for c in richness) or '0'
+        order = 'sequence_number DESC NULLS LAST, ' if has_sequence else ''
+
+        def clear_self_parents():
+            if not has_parent:
+                return
+            reset = 'parent_channel = NULL'
+            if has_parent_sid:
+                reset += ', parent_sid = NULL'
+            cr.execute(
+                'UPDATE connect_channel SET %s WHERE parent_channel = id' % reset)
+
+        clear_self_parents()
+        cr.execute('DROP TABLE IF EXISTS connect_channel_sid_merge')
+        cr.execute(
+            """
+            CREATE TEMP TABLE connect_channel_sid_merge (
+                duplicate_id integer PRIMARY KEY,
+                keeper_id integer NOT NULL
+            ) ON COMMIT DROP
+            """
+        )
+        cr.execute(
+            """
+            INSERT INTO connect_channel_sid_merge (duplicate_id, keeper_id)
+            SELECT id, keeper_id
+            FROM (
+                SELECT
+                    id,
+                    first_value(id) OVER (
+                        PARTITION BY sid
+                        ORDER BY {order}({score}) DESC, id DESC
+                    ) AS keeper_id,
+                    count(*) OVER (PARTITION BY sid) AS duplicate_count
+                FROM connect_channel
+                WHERE sid IS NOT NULL
+            ) ranked
+            WHERE duplicate_count > 1 AND id != keeper_id
+            """.format(order=order, score=score)
+        )
+        if not cr.rowcount:
+            return
+        merged = cr.rowcount
+
+        if has_parent:
+            cr.execute(
+                """
+                UPDATE connect_channel channel
+                   SET parent_channel = merge.keeper_id
+                  FROM connect_channel_sid_merge merge
+                 WHERE channel.parent_channel = merge.duplicate_id
+                """
+            )
+            clear_self_parents()
+        if sql.column_exists(cr, 'connect_recording', 'channel'):
+            cr.execute(
+                """
+                UPDATE connect_recording recording
+                   SET channel = merge.keeper_id
+                  FROM connect_channel_sid_merge merge
+                 WHERE recording.channel = merge.duplicate_id
+                """
+            )
+        if sql.table_exists(cr, 'connect_channel_pbx_group_users_rel'):
+            cr.execute(
+                """
+                INSERT INTO connect_channel_pbx_group_users_rel (
+                    connect_channel_id, res_users_id
+                )
+                SELECT DISTINCT merge.keeper_id, relation.res_users_id
+                  FROM connect_channel_pbx_group_users_rel relation
+                  JOIN connect_channel_sid_merge merge
+                    ON merge.duplicate_id = relation.connect_channel_id
+                ON CONFLICT DO NOTHING
+                """
+            )
+            cr.execute(
+                """
+                DELETE FROM connect_channel_pbx_group_users_rel relation
+                 USING connect_channel_sid_merge merge
+                 WHERE relation.connect_channel_id = merge.duplicate_id
+                """
+            )
+        cr.execute(
+            """
+            DELETE FROM connect_channel channel
+             USING connect_channel_sid_merge merge
+             WHERE channel.id = merge.duplicate_id
+            """
+        )
+        logger.info('Merged %s duplicate channel SID(s)', merged)
 
     @api.depends('caller_user', 'called_user')
     def _compute_pbx_group_user_ids(self):
@@ -186,10 +315,6 @@ class Channel(models.Model):
                     data['parent_sid'] = parent_channel.parent_channel.sid
             channel.write(data)
             debug(self, 'Channel %s updated.' % channel.id)
-
-            # Check for external call termination after transfer recipient hangs up
-            if params['CallStatus'] in CALL_END_STATUSES and channel.call:
-                self._handle_external_call_termination_on_hangup(channel, params)
 
             # Note: Outgoing transfer failures now handled by direct extension redirect
             # No longer need complex failure detection logic
@@ -345,49 +470,6 @@ class Channel(models.Model):
 
         except Exception as e:
             logger.error(f'Error handling failed outgoing transfer: {e}')
-
-    def _handle_external_call_termination_on_hangup(self, channel, params):
-        """
-        Handle external call termination when transfer recipients hang up completed calls.
-        This prevents external callers from going to voicemail when internal users end calls.
-        """
-        try:
-            call = channel.call
-            call_sid = params.get('CallSid')
-            call_status = params.get('CallStatus')
-
-            # Only process if call has transfer context with termination info
-            if not call.transfer_context or '_external_termination' not in call.transfer_context:
-                return
-
-            termination_info = call.transfer_context['_external_termination']
-            transfer_recipient_sid = termination_info.get('transfer_recipient_sid')
-            external_call_sid = termination_info.get('external_call_sid')
-
-            # Check if this is the transfer recipient hanging up
-            if call_sid == transfer_recipient_sid:
-                # Terminate the external call
-                client = self.env['connect.settings'].get_client()
-                try:
-                    # Check if external call is still active
-                    external_call = client.calls(external_call_sid).fetch()
-                    if external_call.status in ['in-progress', 'ringing']:
-                        # Terminate the external call
-                        hangup_result = client.calls(external_call_sid).update(status='completed')
-                except Exception as e:
-                    logger.error(f'Failed to terminate external call {external_call_sid}: {e}')
-
-                # Clean up termination context
-                try:
-                    current_context = call.transfer_context or {}
-                    if '_external_termination' in current_context:
-                        del current_context['_external_termination']
-                        call.transfer_context = current_context
-                except Exception as e:
-                    logger.error(f'Failed to clean up termination context: {e}')
-
-        except Exception as e:
-            logger.error(f'Error handling external call termination: {e}', exc_info=True)
 
     def transfer(self, to=None):
         self.ensure_one()

--- a/connect/models/discuss_channel.py
+++ b/connect/models/discuss_channel.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import base64
 import logging
+import re
 from datetime import timedelta
 
 from markupsafe import Markup
 
 from odoo import api, Command, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import AccessError, ValidationError
 from odoo.tools import file_open, html2plaintext
 from odoo.addons.mail.tools.discuss import Store
 
@@ -25,6 +26,11 @@ class DiscussChannel(models.Model):
         'res.partner', string='Customer', index='btree_not_null')
     # Phone number we last spoke to the customer on; default reply target.
     connect_number = fields.Char(string='Customer Number')
+    # Our line this conversation runs on. Stored per channel so that changing
+    # the default number, or running several numbers at once, never moves an
+    # existing conversation onto another line. Empty on conversations that
+    # predate the field: those keep resolving from their last inbound.
+    connect_sender_number = fields.Char(string='Sending Line')
     # Messaging provider used to reach this customer ('sms' or 'whatsapp').
     connect_channel_provider = fields.Char(string='Channel Provider', default='sms')
     # WhatsApp 24h session window (per Twilio/Meta), WhatsApp messages only.
@@ -116,6 +122,153 @@ class DiscussChannel(models.Model):
             })
         return self.browse()
 
+    @api.model
+    def _connect_normalize_number(self, number):
+        """Return a hand-typed number as clean E.164, or '' when unusable.
+
+        Agents type the number themselves in the New SMS dialog, so it arrives
+        in any shape ('365-737-9035', '13657379035'). Twilio only accepts
+        E.164, and the contact/channel lookups compare against the sanitized
+        form, so anything else silently misses and starts a duplicate thread.
+        """
+        clean_number = (self._connect_parse_number(number)[0] or '').strip()
+        if not clean_number:
+            return ''
+        clean_number = self.env['res.partner']._normalize_phone(clean_number) or ''
+        # _normalize_phone falls back to '+<digits>' when it cannot parse, so a
+        # too-short result means the input was not a phone number at all.
+        if len(re.sub(r'\D', '', clean_number)) < 7:
+            return ''
+        return clean_number
+
+    @api.model
+    def _connect_check_agent(self):
+        if not self.env.user.has_group('connect.group_connect_user') \
+                and not self.env.user.has_group('connect.group_connect_admin'):
+            raise AccessError('Only Connect agents can start SMS conversations.')
+
+    @api.model
+    def connect_sms_sender_options(self):
+        """Lines the New SMS dialog offers, and which one is preselected.
+
+        The default is always offered even when it is not a Twilio number, so
+        a database that sends from a verified caller ID keeps working.
+        """
+        self._connect_check_agent()
+        CallerId = self.env['connect.outgoing_callerid']
+        default = CallerId._get_default_number()
+        options = [{'number': line.number, 'name': line.friendly_name}
+                   for line in CallerId._get_sms_lines()]
+        if default and default not in [o['number'] for o in options]:
+            options.insert(0, {'number': default, 'name': default})
+        return {'default': default, 'options': options}
+
+    @api.model
+    def _connect_resolve_sender(self, sender_number=None):
+        """Validate a line picked in the dialog, or fall back to the default.
+
+        The number comes from the browser, so it is checked against the lines
+        we actually offer rather than handed to Twilio as-is.
+        """
+        if not sender_number:
+            return self.env['connect.message']._get_sender_number()
+        allowed = [o['number'] for o in self.connect_sms_sender_options()['options']]
+        if sender_number not in allowed:
+            raise ValidationError(
+                '%s is not one of the numbers this database can send from.'
+                % sender_number)
+        return sender_number
+
+    def _connect_sms_sender(self):
+        """The line this conversation sends from."""
+        self.ensure_one()
+        if self.connect_sender_number:
+            return self.connect_sender_number
+        # Conversations older than the field: reply on the number the customer
+        # last messaged, exactly as before, so changing the default number
+        # never moves them onto another line.
+        last_inbound = self.env['connect.message'].sudo().search(
+            [('channel_id', '=', self.id), ('status', '=', 'received')],
+            order='create_date desc', limit=1)
+        return (last_inbound.to_number
+                or self.env['connect.message']._get_sender_number())
+
+    @api.model
+    def connect_start_sms_channel(self, number, sender_number=None):
+        """Start or resume an SMS conversation with the given phone number.
+
+        Called from the Discuss sidebar "New SMS" action.  ``number`` is the
+        destination; ``sender_number`` is the line to send from, defaulting to
+        the current default.  Finds an existing connect_messages channel for
+        this number (or its linked partner) and creates the channel, and the
+        contact behind it, when they do not exist yet.  A conversation that
+        already exists keeps the line it is already on.  Returns the channel_id
+        so the frontend can navigate to it.
+        """
+        self._connect_check_agent()
+
+        clean_number = self._connect_normalize_number(number)
+        if not clean_number:
+            raise ValidationError('Please enter a valid phone number.')
+        # Resolve the line here, where the dialog can show what went wrong,
+        # rather than on the first message: Discuss posts silently and only
+        # marks the message with an error icon when the server raises.
+        sender_number = self._connect_resolve_sender(sender_number)
+
+        Partner = self.env['res.partner'].sudo()
+        partner = Partner.get_partner_by_number(clean_number)
+        if not partner:
+            # get_partner_by_number gives up when a number is shared across
+            # companies; pick one of them over creating a duplicate contact.
+            partner = Partner.search([('phone_sanitized', '=', clean_number)], limit=1)
+        channel = self._get_connect_channel(
+            partner=partner, number=clean_number, provider='sms')
+        if partner and not channel:
+            # An earlier inbound may have opened a number-only channel for this
+            # number; reuse it instead of starting a second conversation.
+            channel = self._get_connect_channel(
+                number=clean_number, provider='sms')
+        if not partner:
+            partner = self._connect_create_contact(clean_number)
+        if not channel:
+            channel = self._get_connect_channel(
+                partner=partner, number=clean_number, provider='sms',
+                create_if_not_found=True)
+            # Only a conversation we start here gets the picked line: resuming
+            # one must leave it on the line it has been running on.
+            channel.sudo().connect_sender_number = sender_number
+        elif not channel.connect_partner_id:
+            channel._connect_link_partner(partner)
+
+        # Ensure the current user is a member and the channel is pinned.
+        user_partner = self.env.user.partner_id
+        if user_partner not in channel.channel_member_ids.partner_id:
+            channel.sudo().write({
+                'channel_member_ids': [Command.create({'partner_id': user_partner.id})]
+            })
+        member = channel.channel_member_ids.filtered(
+            lambda m: m.partner_id == user_partner)
+        if member and not member.is_pinned:
+            member.write({'unpin_dt': False})
+
+        return {'channel_id': channel.id}
+
+    @api.model
+    def _connect_create_contact(self, number, partner_name=None):
+        """Create the contact behind a phone-number-only conversation."""
+        # New contacts get Odoo's default mail "smiley" avatar.
+        default_image = False
+        try:
+            with file_open('mail/static/src/img/smiley/avatar.jpg', 'rb') as f:
+                default_image = base64.b64encode(f.read())
+        except Exception:
+            logger.warning('Could not read default contact avatar', exc_info=True)
+        return self.env['res.partner'].sudo().create({
+            'name': partner_name or number,
+            'phone': number,
+            'image_1920': default_image or False,
+        })
+
     def connect_create_partner(self, partner_name=None):
         """Create a contact for a phone-number-only channel and link it to the channel."""
         self.ensure_one()
@@ -126,18 +279,7 @@ class DiscussChannel(models.Model):
         number = self.connect_number
         if not number:
             raise ValidationError('Channel has no phone number')
-        # New contacts get Odoo's default mail "smiley" avatar.
-        default_image = False
-        try:
-            with file_open('mail/static/src/img/smiley/avatar.jpg', 'rb') as f:
-                default_image = base64.b64encode(f.read())
-        except Exception:
-            logger.warning('Could not read default contact avatar', exc_info=True)
-        partner = self.env['res.partner'].sudo().create({
-            'name': partner_name or number,
-            'phone': number,
-            'image_1920': default_image or False,
-        })
+        partner = self._connect_create_contact(number, partner_name)
         self._connect_link_partner(partner)
         return {'partner_id': partner.id, 'partner_name': partner.display_name}
 
@@ -166,6 +308,12 @@ class DiscussChannel(models.Model):
         screenshot in the feature request).
         """
         self.ensure_one()
+        # Answer on the line the customer wrote to. This also stamps the line
+        # on conversations older than the field, and on the first inbound of a
+        # conversation the customer started.
+        if connect_message._provider() == 'sms' and connect_message.to_number \
+                and self.connect_sender_number != connect_message.to_number:
+            self.sudo().connect_sender_number = connect_message.to_number
         partner = connect_message.partner
         body_txt = connect_message.body or ''
         if connect_message.media_url:
@@ -288,13 +436,12 @@ class DiscussChannel(models.Model):
         res_id = partner.id or None
         res_model = 'res.partner' if res_id else None
 
-        # Find the last inbound message so we know which of our Twilio numbers
-        # the customer originally messaged — reply from that same line.
-        last_inbound = self.env['connect.message'].sudo().search(
-            [('channel_id', '=', self.id), ('status', '=', 'received')],
-            order='create_date desc', limit=1)
-
         if provider == 'whatsapp':
+            # Find the last inbound message so we know which of our Twilio
+            # numbers the customer originally messaged — reply from that line.
+            last_inbound = self.env['connect.message'].sudo().search(
+                [('channel_id', '=', self.id), ('status', '=', 'received')],
+                order='create_date desc', limit=1)
             Sender = self.env['connect.whatsapp_sender']
             if sender_id:
                 wa_sender = Sender.sudo().browse(int(sender_id))
@@ -311,9 +458,10 @@ class DiscussChannel(models.Model):
                 raise_on_error=True, skip_chatter=True)
         else:
             media_urls = self._connect_media_urls(message)
-            callerid = sender_id or None
-            if not callerid and last_inbound:
-                callerid = last_inbound.to_number or None
+            # Stay on this conversation's own line, so changing the default
+            # number never moves conversations already under way.
+            callerid = (self._connect_resolve_sender(sender_id) if sender_id
+                        else self._connect_sms_sender())
             cmsg = self.env['connect.message'].send(
                 recipient, body, res_id=res_id, res_model=res_model,
                 outgoing_callerid=callerid, media_urls=media_urls,

--- a/connect/models/domain.py
+++ b/connect/models/domain.py
@@ -517,8 +517,9 @@ class Domain(models.Model):
         debug(self, "Domain call to %s" % request.get("To"))
         if not self.env["oduist.license"].check_license('connect'):
             return "<Response><Pause length='1'/><Say>This is Oduist Connect. Your trial period is over. Please buy a license to continue.</Say><Pause length='1'/></Response>"
-        # Create call + channel
-        self.env["connect.call"].on_call_status(request)
+        # Routing needs the root aggregate synchronously; lifecycle projection is
+        # handled independently by the status callback inbox.
+        self.env["connect.call"].ensure_initial_call(request)
         to_val = request.get("To") or ''
         # Extract number for SIP or WhatsApp channels
         found = re.search(r"^sip:(.+)@(.+)\.sip\.((.+)\.)?twilio\.com", to_val)

--- a/connect/models/mail.py
+++ b/connect/models/mail.py
@@ -8,10 +8,12 @@ class MailMessage(models.Model):
     message_type = fields.Selection(
         selection_add=[
             ('WhatsApp', 'WhatsApp'),
+            ('mms', 'MMS'),
             ('connect_message', 'Connect Message'),
         ],
         ondelete={
             'WhatsApp': lambda recs: recs.write({'message_type': 'comment'}),
+            'mms': lambda recs: recs.write({'message_type': 'comment'}),
             'connect_message': lambda recs: recs.write({'message_type': 'comment'}),
         },
     )

--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -455,6 +455,23 @@ class ConnectMessage(models.Model):
             }])
         return chatter
 
+    @api.model
+    def _get_sender_number(self):
+        """Number outgoing messages are sent from.
+
+        The Connect default outgoing caller ID. The agent's own caller ID is
+        only used when the database has no default configured at all, and
+        without either we cannot send: Twilio always requires a From.
+        """
+        sender = self.env['connect.outgoing_callerid']._get_default_number()
+        if not sender:
+            sender = self.env.user.connect_user.outgoing_callerid.number
+        if not sender:
+            raise ValidationError(
+                'No default outgoing number is set. Mark one caller ID as '
+                'Default in Connect to send messages.')
+        return sender
+
     def send(self, recipient, body, res_id=None, res_model=None, outgoing_callerid=None, media_urls=None, skip_chatter=False):
         self.env['oduist.license'].check_license('connect', silent=False)
         sender_user = self.env.user
@@ -467,14 +484,7 @@ class ConnectMessage(models.Model):
             'res_model': res_model,
             'status': 'sent'
         }
-        if outgoing_callerid:
-            sender = outgoing_callerid
-        else:
-            number = sender_user.connect_user.outgoing_callerid
-            # Check if user have a number
-            if not number:
-                raise ValidationError('You dont have an outgoing callerid number!')
-            sender = number.number
+        sender = outgoing_callerid or self._get_sender_number()
         message = self.client_send(recipient, sender, body, media_urls=media_urls)
         if not message:
             raise ValidationError('Unexpected error! Contact admin or maintainer!')

--- a/connect/models/number.py
+++ b/connect/models/number.py
@@ -186,8 +186,9 @@ class Number(models.Model):
     @api.model
     def route_call(self, request, params={}):
         debug(self, 'Route number call: %s' % json.dumps(request, indent=2))
-        # Create call
-        self.env['connect.call'].on_call_status(request)
+        # Routing needs the root aggregate synchronously; lifecycle projection is
+        # handled independently by the status callback inbox.
+        self.env['connect.call'].ensure_initial_call(request)
         # Find the number
         number = self.sudo().search([('phone_number', '=', request['Called'])])
         if not number:

--- a/connect/models/outgoing_callerid.py
+++ b/connect/models/outgoing_callerid.py
@@ -40,6 +40,25 @@ class OutgoingCallerID(models.Model):
         for rec in self:
             rec.name = '{} "{}"'.format(rec.number, rec.friendly_name)
 
+    @api.model
+    def _get_sms_lines(self):
+        """Caller IDs a message can be sent from.
+
+        Only real Twilio numbers: a verified caller ID is voice-only and
+        Twilio rejects it as the From of a message.
+        """
+        return self.sudo().search([('callerid_type', '=', 'number')])
+
+    @api.model
+    def _get_default_number(self):
+        """Number of the caller ID flagged as Default, or False.
+
+        Outgoing messages always leave from this line, so the lookup is by the
+        ``is_default`` flag and never by a hardcoded number: any database only
+        has to mark one caller ID as Default in Connect.
+        """
+        return self.sudo().search([('is_default', '=', True)], limit=1).number
+
     def sync_outgoing_callerid(self, callerid_type):
         client = self.env['connect.settings'].get_client(region=False)
         if callerid_type == 'outgoing_callerid':

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -245,6 +245,14 @@ class Settings(models.Model):
 
     name = fields.Char(compute="_get_name")
     debug_mode = fields.Boolean()
+    delete_processed_call_events = fields.Boolean(
+        string="Delete processed call events",
+        default=True,
+        help=(
+            "Delete successfully projected Twilio lifecycle events and completed "
+            "runtime attempts immediately. Disable to retain them for one hour."
+        ),
+    )
     twilio_auto_sync = fields.Boolean(default=True)
     twilio_region = fields.Selection([
         ('us1', 'US'),

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -374,6 +374,21 @@ class User(models.Model):
             caller_name = caller_user.name
         return caller_name
 
+    def _ensure_direct_call_attempt(self, call, params):
+        """Record the leg expected from a synchronous Dial response."""
+        if not call or params.get('_is_transfer_redirect'):
+            return
+        pending = call.attempt_ids.filtered(
+            lambda attempt: attempt.kind == 'direct_call'
+            and attempt.state == 'pending'
+            and attempt.target_user_id == self.user
+        )[:1]
+        if not pending:
+            call._set_webhook_expectation('direct_call', {
+                'expected_count': 1,
+                'target_user_id': self.user.id,
+            })
+
     def render_client(self, response, request, params):
         caller_name = self._get_caller_name(request, params)
         callerId = self._get_caller_id(request, params)
@@ -427,6 +442,7 @@ class User(models.Model):
             partner_id = False
         client.parameter(name='Partner', value=partner_id)
         dial_client.append(client)
+        self._ensure_direct_call_attempt(call, params)
         response.append(dial_client)
 
     def render_sip(self, response, request, params):
@@ -463,6 +479,7 @@ class User(models.Model):
             'sip:{}{}'.format(self.uri, ';secure=true' if self.domain.secure_media else ''),
             statusCallbackEvent='initiated answered completed',
             statusCallback=status_url)
+        self._ensure_direct_call_attempt(call, params)
         response.append(dial_sip)
 
 

--- a/connect/security/admin.xml
+++ b/connect/security/admin.xml
@@ -175,6 +175,36 @@
     <field name="perm_unlink" eval="1"/>
   </record>
 
+  <record id="connect_call_event_admin" model="ir.model.access">
+    <field name="name">connect_call_event_admin</field>
+    <field name="model_id" ref="connect.model_connect_call_event"/>
+    <field name="group_id" ref="connect.group_connect_admin"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="0"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
+  <record id="connect_call_attempt_admin" model="ir.model.access">
+    <field name="name">connect_call_attempt_admin</field>
+    <field name="model_id" ref="connect.model_connect_call_attempt"/>
+    <field name="group_id" ref="connect.group_connect_admin"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="0"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
+  <record id="connect_call_event_dedup_admin" model="ir.model.access">
+    <field name="name">connect_call_event_dedup_admin</field>
+    <field name="model_id" ref="connect.model_connect_call_event_dedup"/>
+    <field name="group_id" ref="connect.group_connect_admin"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="0"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
 <!-- Recording -->
   <record id="connect_recording_admin" model="ir.model.access">
     <field name="name">connect_recording_admin</field>

--- a/connect/security/user.xml
+++ b/connect/security/user.xml
@@ -174,6 +174,16 @@
     <field name="perm_unlink" eval="0"/>
   </record>
 
+  <record id="connect_call_attempt_user" model="ir.model.access">
+    <field name="name">connect_call_attempt_user</field>
+    <field name="model_id" ref="connect.model_connect_call_attempt"/>
+    <field name="group_id" ref="connect.group_connect_user"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="0"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
 <!-- Recording -->
   <record id="connect_recording_user" model="ir.model.access">
     <field name="name">connect_recording_user</field>

--- a/connect/security/webhook.xml
+++ b/connect/security/webhook.xml
@@ -67,6 +67,26 @@
     <field name="perm_unlink" eval="0"/>
   </record>
 
+  <record id="connect_call_event_webhook" model="ir.model.access">
+    <field name="name">connect_call_event_webhook</field>
+    <field name="model_id" ref="connect.model_connect_call_event"/>
+    <field name="group_id" ref="connect.group_connect_webhook"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="1"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
+  <record id="connect_call_attempt_webhook" model="ir.model.access">
+    <field name="name">connect_call_attempt_webhook</field>
+    <field name="model_id" ref="connect.model_connect_call_attempt"/>
+    <field name="group_id" ref="connect.group_connect_webhook"/>
+    <field name="perm_read" eval="1"/>
+    <field name="perm_write" eval="0"/>
+    <field name="perm_create" eval="0"/>
+    <field name="perm_unlink" eval="0"/>
+  </record>
+
   <!-- Number -->
   <record id="connect_number_webhook" model="ir.model.access">
     <field name="name">connect_number_webhook</field>

--- a/connect/static/src/core/public_web/discuss_search_patch.js
+++ b/connect/static/src/core/public_web/discuss_search_patch.js
@@ -1,0 +1,81 @@
+/* @odoo-module */
+import { DiscussSearch } from "@mail/core/public_web/discuss_search";
+import { NewSmsDialog } from "@connect/core/web/new_sms_dialog";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { useHover } from "@mail/utils/common/hooks";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+
+patch(DiscussSearch.prototype, {
+    setup() {
+        super.setup();
+        this.dialogService = useService("dialog");
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+        this.smsHover = useHover(["sms-btn", "sms-floating"], {
+            onHover: () => {
+                if (this.store.discuss.isSidebarCompact) {
+                    this.newSmsFloating.isOpen = true;
+                }
+            },
+            onAway: () => {
+                if (this.store.discuss.isSidebarCompact) {
+                    this.newSmsFloating.isOpen = false;
+                }
+            },
+        });
+        this.newSmsFloating = useDropdownState();
+    },
+
+    get newSmsText() {
+        return _t("New SMS");
+    },
+
+    async onClickNewSms() {
+        let senders = { options: [], default: false };
+        try {
+            senders = await this.orm.call(
+                "discuss.channel",
+                "connect_sms_sender_options",
+                [],
+            );
+        } catch {
+            // Offering no choice still lets the server pick the default line.
+        }
+        this.dialogService.add(NewSmsDialog, {
+            senders: senders.options,
+            defaultSender: senders.default,
+            onSubmit: async (number, senderNumber) => {
+                await this._startSmsChannel(number, senderNumber);
+            },
+        });
+    },
+
+    async _startSmsChannel(number, senderNumber) {
+        try {
+            const result = await this.orm.call(
+                "discuss.channel",
+                "connect_start_sms_channel",
+                [number, senderNumber || false],
+            );
+            if (result?.channel_id) {
+                const thread = await this.store.Thread.getOrFetch({
+                    model: "discuss.channel",
+                    id: result.channel_id,
+                });
+                if (thread) {
+                    thread.setAsDiscussThread();
+                }
+            }
+        } catch (e) {
+            // Show what the server said (invalid number, no default outgoing
+            // number, ...) — a generic message leaves the agent with nothing
+            // to act on.
+            this.notification.add(
+                e?.data?.message || _t("Failed to start SMS conversation."),
+                { type: "warning" },
+            );
+        }
+    },
+});

--- a/connect/static/src/core/public_web/discuss_search_patch.xml
+++ b/connect/static/src/core/public_web/discuss_search_patch.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.DiscussSearch" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='store.self.main_user_id']" position="after">
+            <t t-if="store.self.main_user_id">
+                <Dropdown t-if="store.discuss.isSidebarCompact and !ui.isSmall" state="newSmsFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu px-2 mx-2 my-0 min-w-0 ' + store.discussDropdownMenuClass(this)" manual="true">
+                    <t t-call="mail.DiscussSearch.newSms"/>
+                    <t t-set-slot="content">
+                        <div t-ref="sms-floating">
+                            <span class="text-muted user-select-none" t-esc="newSmsText"/>
+                        </div>
+                    </t>
+                </Dropdown>
+                <t t-else="" t-call="mail.DiscussSearch.newSms"/>
+            </t>
+        </xpath>
+    </t>
+
+    <t t-name="mail.DiscussSearch.newSms">
+        <button class="btn btn-primary d-flex align-items-center gap-1 ms-1" t-att-title="newSmsText" t-on-click="onClickNewSms" t-ref="sms-btn" t-att-class="{
+            'rounded-2': true,
+            'p-2': ui.isSmall,
+            'o-px-1_5 py-2': !ui.isSmall and store.discuss.isSidebarCompact,
+            'o-p-1_5': !ui.isSmall and !store.discuss.isSidebarCompact,
+        }">
+            <i class="fa fa-commenting-o"/>
+        </button>
+    </t>
+</templates>

--- a/connect/static/src/core/web/new_sms_dialog.js
+++ b/connect/static/src/core/web/new_sms_dialog.js
@@ -1,0 +1,42 @@
+/* @odoo-module */
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+import { Component, onMounted, useState, useRef } from "@odoo/owl";
+
+export class NewSmsDialog extends Component {
+    static template = "connect.NewSmsDialog";
+    static components = { Dialog };
+    static props = {
+        close: Function,
+        onSubmit: Function,
+        // Lines this database can send from, and the one to preselect. With a
+        // single line there is nothing to choose, so the picker stays hidden.
+        senders: { type: Array, optional: true },
+        defaultSender: { type: [String, Boolean], optional: true },
+    };
+    static defaultProps = { senders: [], defaultSender: false };
+
+    setup() {
+        this.title = _t("New SMS Conversation");
+        this.state = useState({
+            number: "",
+            sender: this.props.defaultSender || this.props.senders[0]?.number || "",
+        });
+        this.inputRef = useRef("autofocus");
+        onMounted(() => this.inputRef.el?.focus());
+    }
+
+    get hasSenderChoice() {
+        return this.props.senders.length > 1;
+    }
+
+    get isValid() {
+        return this.state.number.trim().length > 0;
+    }
+
+    async onConfirm() {
+        if (!this.isValid) return;
+        await this.props.onSubmit(this.state.number.trim(), this.state.sender);
+        this.props.close();
+    }
+}

--- a/connect/static/src/core/web/new_sms_dialog.xml
+++ b/connect/static/src/core/web/new_sms_dialog.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="connect.NewSmsDialog">
+        <Dialog size="'sm'" title="title">
+            <div class="mb-3">
+                <label for="connect_sms_number" class="form-label">Phone Number</label>
+                <input
+                    id="connect_sms_number"
+                    type="tel"
+                    class="form-control"
+                    placeholder="+1234567890"
+                    t-att-value="state.number"
+                    t-on-input="(ev) => this.state.number = ev.target.value"
+                    t-on-keydown="(ev) => ev.key === 'Enter' &amp;&amp; this.onConfirm()"
+                    t-ref="autofocus"
+                />
+                <div class="form-text">Enter the number in international format (e.g. +1234567890)</div>
+            </div>
+            <div class="mb-3" t-if="hasSenderChoice">
+                <label for="connect_sms_sender" class="form-label">Send From</label>
+                <select
+                    id="connect_sms_sender"
+                    class="form-select"
+                    t-on-change="(ev) => this.state.sender = ev.target.value"
+                >
+                    <option
+                        t-foreach="props.senders"
+                        t-as="sender"
+                        t-key="sender.number"
+                        t-att-value="sender.number"
+                        t-att-selected="sender.number === state.sender"
+                    ><t t-esc="sender.name and sender.name !== sender.number ? sender.number + ' — ' + sender.name : sender.number"/></option>
+                </select>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="onConfirm" t-att-disabled="!isValid">Start Conversation</button>
+                <button class="btn btn-secondary" t-on-click="props.close">Cancel</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import test_s3_utils
 from . import test_s3_settings
+from . import test_call_event
 from . import test_connect_discuss_channel
+from . import test_call_parking

--- a/connect/tests/test_call_event.py
+++ b/connect/tests/test_call_event.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCallEventProjector(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.settings = cls.env["connect.settings"].sudo()
+        cls.settings.set_param("delete_processed_call_events", False)
+        cls.event_model = cls.env["connect.call.event"].sudo()
+        cls.call_model = cls.env["connect.call"].sudo()
+        cls.root_sid = "CA_PROJECTOR_ROOT"
+        cls.base_payload = {
+            "CallSid": cls.root_sid,
+            "Direction": "inbound",
+            "Caller": "+15550000001",
+            "Called": "+15550000002",
+            "To": "+15550000002",
+            "CallStatus": "ringing",
+            "SequenceNumber": "0",
+        }
+        cls.call = cls.call_model.ensure_initial_call(cls.base_payload)
+
+    def test_ingest_is_idempotent(self):
+        first = self.event_model.ingest(
+            "call_status", self.base_payload, token="same-token"
+        )
+        second = self.event_model.ingest(
+            "call_status", self.base_payload, token="same-token"
+        )
+        self.assertEqual(first, second)
+        self.assertEqual(
+            self.event_model.search_count(
+                [("dedup_key", "=", first.dedup_key)]
+            ),
+            1,
+        )
+
+    def test_older_sequence_cannot_regress_channel(self):
+        completed = dict(
+            self.base_payload,
+            CallStatus="completed",
+            SequenceNumber="2",
+            CallDuration="12",
+        )
+        self.event_model.ingest("call_status", completed, token="sequence-2")
+        self.event_model.process_pending_events()
+        channel = self.env["connect.channel"].search(
+            [("sid", "=", self.root_sid)]
+        )
+        self.assertEqual(channel.status, "completed")
+        self.assertEqual(channel.sequence_number, 2)
+
+        stale = dict(
+            self.base_payload,
+            CallStatus="in-progress",
+            SequenceNumber="1",
+            CallDuration="3",
+        )
+        self.event_model.ingest("call_status", stale, token="sequence-1")
+        self.event_model.process_pending_events()
+        self.assertEqual(channel.status, "completed")
+        self.assertEqual(channel.duration, 12)
+        self.assertEqual(channel.sequence_number, 2)
+
+    def test_timestamp_orders_events_without_sequence(self):
+        channel = self.call.channels[:1]
+        channel.write(
+            {
+                "status": "ringing",
+                "duration": 0,
+                "sequence_number": 4,
+                "event_timestamp": "2026-01-01 00:00:00",
+            }
+        )
+        payload = dict(
+            self.base_payload,
+            CallStatus="completed",
+            CallDuration="6",
+            Timestamp="2026-01-01T00:00:05Z",
+        )
+        payload.pop("SequenceNumber")
+        self.event_model.ingest(
+            "call_status", payload, token="timestamp-only"
+        )
+        self.event_model.process_pending_events()
+        self.assertEqual(channel.status, "completed")
+        self.assertEqual(channel.duration, 6)
+        self.assertEqual(channel.sequence_number, 4)
+
+    def test_voicemail_is_projected(self):
+        payload = {
+            "CallSid": self.root_sid,
+            "RecordingUrl": "https://example.invalid/recording",
+            "RecordingDuration": "9",
+        }
+        self.event_model.ingest(
+            "voicemail_status", payload, token="voicemail"
+        )
+        self.event_model.process_pending_events()
+        self.assertEqual(
+            self.call.voicemail_url, "https://example.invalid/recording"
+        )
+        self.assertEqual(self.call.voicemail_duration, 9)
+
+    def test_unknown_parent_is_retried(self):
+        payload = {
+            "CallSid": "CA_UNKNOWN_CHILD",
+            "ParentCallSid": "CA_UNKNOWN_PARENT",
+            "Direction": "outbound-dial",
+            "Caller": "+15550000001",
+            "Called": "sip:100@example.invalid",
+            "To": "sip:100@example.invalid",
+            "CallStatus": "ringing",
+            "SequenceNumber": "0",
+        }
+        event = self.event_model.ingest(
+            "call_status", payload, token="unknown-parent"
+        )
+        self.event_model.process_pending_events()
+        self.assertEqual(event.state, "pending")
+        self.assertTrue(event.next_attempt_at)
+        self.assertIn("has not arrived", event.error_message)
+
+    def test_generic_dial_action_does_not_create_transfer_channel(self):
+        attempt = self.env["connect.call.attempt"].create(
+            {
+                "kind": "ring_group",
+                "call_id": self.call.id,
+                "parent_sid": self.root_sid,
+                "expected_count": 2,
+            }
+        )
+        payload = {
+            "CallSid": self.root_sid,
+            "DialCallSid": "CA_GENERIC_DIAL_CHILD",
+            "DialCallStatus": "no-answer",
+            "DialCallDuration": "0",
+            "ConnectActionModel": "connect.callflow",
+            "ConnectActionRecordId": 42,
+        }
+        event = self.event_model.ingest(
+            "dial_action", payload, token="generic-dial"
+        )
+        self.event_model.process_pending_events()
+        self.assertEqual(event.state, "done")
+        self.assertEqual(attempt.state, "resolved")
+        self.assertFalse(
+            self.env["connect.channel"].search(
+                [("sid", "=", "CA_GENERIC_DIAL_CHILD")]
+            )
+        )
+
+    def test_generic_dial_action_cannot_regress_leg_status(self):
+        child = self.env["connect.channel"].create(
+            {
+                "sid": "CA_GENERIC_EXISTING_CHILD",
+                "call": self.call.id,
+                "parent_channel": self.call.channels[:1].id,
+                "parent_sid": self.root_sid,
+                "technical_direction": "outbound-dial",
+                "status": "completed",
+                "duration": 8,
+                "sequence_number": 3,
+            }
+        )
+        self.event_model.ingest(
+            "dial_action",
+            {
+                "CallSid": self.root_sid,
+                "DialCallSid": child.sid,
+                "DialCallStatus": "no-answer",
+                "DialCallDuration": "0",
+                "ConnectActionModel": "connect.user",
+                "ConnectActionRecordId": 42,
+            },
+            token="generic-dial-stale",
+        )
+        self.event_model.process_pending_events()
+        self.assertEqual(child.status, "completed")
+        self.assertEqual(child.duration, 8)
+
+    def test_transfer_command_is_prepared_for_postcommit(self):
+        self.env["connect.call.attempt"].create(
+            {
+                "kind": "external_leg",
+                "call_id": self.call.id,
+                "parent_sid": self.root_sid,
+                "external_sid": "CA_EXTERNAL_LEG",
+            }
+        )
+        transfer = self.env["connect.call.attempt"].create(
+            {
+                "kind": "transfer",
+                "call_id": self.call.id,
+                "parent_sid": self.root_sid,
+                "dial_call_sid": "CA_TRANSFER_CHILD",
+            }
+        )
+        event = self.event_model.ingest(
+            "dial_action",
+            {
+                "CallSid": self.root_sid,
+                "DialCallSid": "CA_TRANSFER_CHILD",
+                "DialCallStatus": "completed",
+                "DialCallDuration": "7",
+                "ConnectActionModel": "connect.call",
+            },
+            token="transfer-command",
+        )
+        self.event_model.process_pending_events()
+        self.assertEqual(transfer.state, "resolved")
+        self.assertEqual(event.command_state, "pending")
+        self.assertEqual(
+            event.command_payload["call_sid"], "CA_EXTERNAL_LEG"
+        )
+
+    def test_immediate_retention_deletes_done_event(self):
+        self.settings.set_param("delete_processed_call_events", True)
+        payload = dict(
+            self.base_payload,
+            CallStatus="in-progress",
+            SequenceNumber="3",
+        )
+        event = self.event_model.ingest(
+            "call_status", payload, token="delete-done"
+        )
+        event_id = event.id
+        dedup_key = event.dedup_key
+        self.event_model.process_pending_events()
+        self.assertFalse(self.event_model.browse(event_id).exists())
+        duplicate = self.event_model.ingest(
+            "call_status", payload, token="delete-done"
+        )
+        self.assertFalse(duplicate)
+        self.assertEqual(
+            self.env["connect.call.event.dedup"].search_count(
+                [("dedup_key", "=", dedup_key)]
+            ),
+            1,
+        )

--- a/connect/tests/test_call_parking.py
+++ b/connect/tests/test_call_parking.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestCallParking(TransactionCase):
+    """Park / retrieve keeps the customer's caller ID and call history."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['connect.settings'].set_param('api_url', 'https://pbx.example.com/')
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Acme Customer', 'phone': '+12898283865',
+        })
+        # Twilio is never reachable from tests: the domain create() builds a
+        # client even when no_twilio_create skips the provisioning itself.
+        with patch.object(type(cls.env['connect.settings']), 'get_client',
+                          return_value=MagicMock()):
+            cls.domain = cls.env['connect.domain'].with_context(
+                no_twilio_create=True).create({
+                    'subdomain': 'test-parking', 'friendly_name': 'Test Parking',
+                })
+            cls.agent = cls.env['connect.user'].with_context(
+                no_twilio_create=True).create({
+                    'username': 'ParkTester', 'domain': cls.domain.id,
+                    'sip_enabled': True, 'client_enabled': False,
+                    'record_calls': False,
+                })
+        cls.agent_uri = 'sip:ParkTester@%s' % cls.domain.domain_name
+
+    def _make_call(self, sid, caller, called, direction, partner=None):
+        call = self.env['connect.call'].create({
+            'caller': caller, 'called': called, 'direction': direction,
+            'status': 'in-progress', 'partner': partner.id if partner else False,
+        })
+        self.env['connect.channel'].create({
+            'sid': sid, 'call': call.id, 'caller': caller, 'called': called,
+            'status': 'in-progress', 'technical_direction': 'inbound',
+        })
+        return call
+
+    def _park(self, call_sid, slot='702'):
+        return self.env['connect.call'].park_call(
+            {'CallSid': call_sid, 'Caller': self.agent_uri},
+            {'ExtenNumber': '*%s' % slot})
+
+    def test_park_records_slot_on_the_call(self):
+        call = self._make_call('CAcustomer', '+12898283865', '+13658257665',
+                               'incoming', self.partner)
+        self._park('CAcustomer')
+        self.assertEqual(call.park_slot, '702')
+        self.assertEqual(call.park_call_sid, 'CAcustomer')
+        self.assertEqual(call.parked_by_pbx_user, self.agent)
+        self.assertTrue(call.parked_at)
+
+    def test_retrieval_dials_back_with_the_original_caller_id(self):
+        parked = self._make_call('CAcustomer', '+12898283865', '+13658257665',
+                                 'incoming', self.partner)
+        self._park('CAcustomer')
+        retrieval = self._make_call('CAretrieval', '206', '702', 'outgoing')
+        twilio = MagicMock()
+        with patch.object(type(self.env['connect.settings']), 'get_client',
+                          return_value=twilio):
+            response = self.env['connect.call'].unpark_call(
+                {'CallSid': 'CAretrieval', 'Caller': self.agent_uri},
+                {'ExtenNumber': '702'})
+        # The agent's "dialed the slot" leg is released...
+        self.assertIn('<Hangup', str(response))
+        self.assertNotIn('<Queue', str(response))
+        # ...and the parked call dials the agent back with the customer's number.
+        twilio.calls.assert_called_once_with('CAcustomer')
+        twiml = twilio.calls.return_value.update.call_args.kwargs['twiml']
+        self.assertIn('callerId="+12898283865"', twiml)
+        self.assertIn(self.agent_uri, twiml)
+        self.assertNotIn('<Queue', twiml)
+        # Slot is freed, the SID is kept so an unanswered retrieval can re-park.
+        self.assertFalse(parked.park_slot)
+        self.assertEqual(parked.park_call_sid, 'CAcustomer')
+        # The retrieval leg is no longer an orphan "206 -> 702" call.
+        self.assertEqual(retrieval.parent_call, parked)
+        self.assertEqual(retrieval.partner, self.partner)
+
+    def test_retrieval_falls_back_to_queue_when_nothing_is_tracked(self):
+        self._make_call('CAretrieval', '206', '702', 'outgoing')
+        response = self.env['connect.call'].unpark_call(
+            {'CallSid': 'CAretrieval', 'Caller': self.agent_uri},
+            {'ExtenNumber': '702'})
+        self.assertIn('<Queue>park-702</Queue>', str(response))
+
+    def test_retrieval_falls_back_to_queue_on_twilio_error(self):
+        parked = self._make_call('CAcustomer', '+12898283865', '+13658257665',
+                                 'incoming', self.partner)
+        self._park('CAcustomer')
+        twilio = MagicMock()
+        twilio.calls.return_value.update.side_effect = Exception('Twilio is down')
+        with patch.object(type(self.env['connect.settings']), 'get_client',
+                          return_value=twilio):
+            response = self.env['connect.call'].unpark_call(
+                {'CallSid': 'CAretrieval', 'Caller': self.agent_uri},
+                {'ExtenNumber': '702'})
+        self.assertIn('<Queue>park-702</Queue>', str(response))
+        # The call stays parked, so a later retrieval can still find it.
+        self.assertEqual(parked.park_slot, '702')
+
+    def test_unanswered_retrieval_re_parks_the_caller(self):
+        parked = self._make_call('CAcustomer', '+12898283865', '+13658257665',
+                                 'incoming', self.partner)
+        self._park('CAcustomer')
+        parked.park_slot = False
+        response = self.env['connect.call'].on_park_retrieve_action(
+            parked.id, '702', {'DialCallStatus': 'no-answer'})
+        self.assertIn('<Enqueue>park-702</Enqueue>', str(response))
+        self.assertEqual(parked.park_slot, '702')
+
+    def test_answered_retrieval_clears_the_parking_state(self):
+        parked = self._make_call('CAcustomer', '+12898283865', '+13658257665',
+                                 'incoming', self.partner)
+        self._park('CAcustomer')
+        response = self.env['connect.call'].on_park_retrieve_action(
+            parked.id, '702', {'DialCallStatus': 'completed'})
+        self.assertIn('<Hangup', str(response))
+        self.assertFalse(parked.park_slot)
+        self.assertFalse(parked.park_call_sid)

--- a/connect/tests/test_connect_discuss_channel.py
+++ b/connect/tests/test_connect_discuss_channel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tests import tagged
 
@@ -31,6 +32,27 @@ class TestConnectDiscussChannel(TransactionCase):
                 (4, cls.env.ref('connect.group_connect_user').id),
             ],
         })
+        # The line every outgoing message is sent from.
+        cls.default_callerid = cls.env['connect.outgoing_callerid'].create({
+            'friendly_name': 'Main line', 'number': '+15559990000',
+            'callerid_type': 'number', 'is_default': True,
+        })
+
+    # Destination for the New SMS tests. These assert on find-or-create, so the
+    # number must have no contact or conversation of its own: a real number
+    # would match live data and the tests would resume that instead of their
+    # own fixture. 555-01xx is the reserved fictional range.
+    NEW_SMS_NUMBER = '+12125550111'
+
+    def _assert_new_sms_number_unused(self):
+        """Fail loudly if the destination picked above ever gains real data."""
+        self.assertFalse(self.Channel.sudo().search([
+            ('channel_type', '=', 'connect_messages'),
+            ('connect_number', '=', self.NEW_SMS_NUMBER),
+        ]), '%s must not already have a conversation' % self.NEW_SMS_NUMBER)
+        self.assertFalse(self.env['res.partner'].sudo().search([
+            ('phone_sanitized', '=', self.NEW_SMS_NUMBER),
+        ]), '%s must not already have a contact' % self.NEW_SMS_NUMBER)
 
     def _make_incoming(self, body='hi there', mtype='sms', number='+15551230000'):
         return self.env['connect.message'].sudo().create({
@@ -138,11 +160,13 @@ class TestConnectDiscussChannel(TransactionCase):
         with patch.object(type(self.env['connect.message']), 'client_send', return_value=_Fake()):
             msg = ch.with_user(self.agent).message_post(
                 body='reply text', message_type='connect_message',
-                connect_provider='sms', connect_sender_id='+15550000000')
+                connect_provider='sms')
         cmsg = self.env['connect.message'].search([('channel_message_id', '=', msg.id)])
         self.assertTrue(cmsg, "Outbound must create a linked connect.message")
         self.assertEqual(cmsg.to_number, '+15551230000')
         self.assertEqual(cmsg.channel_id, ch)
+        self.assertEqual(cmsg.from_number, self.default_callerid.number,
+                         'a channel with no line of its own falls back to the default')
 
     def test_inbound_mirror_does_not_send(self):
         from unittest.mock import patch
@@ -438,6 +462,166 @@ class TestConnectDiscussChannel(TransactionCase):
         self.assertFalse(self.Channel.search([
             ('channel_type', '=', 'connect_messages'),
             ('connect_partner_id', '=', cust.id)]))
+
+    def test_start_sms_channel_normalizes_number_and_creates_contact(self):
+        """The typed number is the destination only: it is normalized to E.164
+        and gets a contact of its own when the number is unknown."""
+        self._assert_new_sms_number_unused()
+        res = self.Channel.with_user(self.agent).connect_start_sms_channel(
+            ' +1 (212) 555-0111 ')
+        channel = self.Channel.browse(res['channel_id'])
+        self.assertEqual(channel.channel_type, 'connect_messages')
+        self.assertEqual(channel.connect_number, self.NEW_SMS_NUMBER)
+        self.assertTrue(channel.connect_partner_id, 'contact must be created')
+        self.assertEqual(channel.connect_partner_id.phone_sanitized,
+                         self.NEW_SMS_NUMBER)
+        self.assertIn(channel.connect_partner_id, channel.channel_member_ids.partner_id)
+        self.assertIn(self.agent.partner_id, channel.channel_member_ids.partner_id)
+
+    def test_start_sms_channel_reuses_known_contact(self):
+        """A number that already has a contact must not get a second one."""
+        cust = self.env['res.partner'].create({
+            'name': 'Known Cust', 'phone': '+12125550160'})
+        self.assertTrue(cust.phone_sanitized, 'precondition: number must sanitize')
+        res = self.Channel.with_user(self.agent).connect_start_sms_channel(
+            '+1 212-555-0160')
+        channel = self.Channel.browse(res['channel_id'])
+        self.assertEqual(channel.connect_partner_id, cust)
+
+    def test_start_sms_channel_reuses_number_only_channel(self):
+        """A conversation opened by an earlier inbound is resumed, and the new
+        contact is linked to it instead of a second thread being created."""
+        self._assert_new_sms_number_unused()
+        existing = self.Channel._get_connect_channel(
+            number=self.NEW_SMS_NUMBER, provider='sms', create_if_not_found=True)
+        self.assertFalse(existing.connect_partner_id, 'precondition: no contact')
+        res = self.Channel.with_user(self.agent).connect_start_sms_channel(
+            '+1 212 555 0111')
+        self.assertEqual(res['channel_id'], existing.id,
+                         'must resume the conversation, not start a second one')
+        self.assertTrue(existing.connect_partner_id, 'contact must be linked')
+
+    def test_start_sms_channel_rejects_invalid_number(self):
+        with self.assertRaises(ValidationError):
+            self.Channel.with_user(self.agent).connect_start_sms_channel('not a number')
+
+    def test_start_sms_channel_without_default_number_raises(self):
+        """Without a default line we cannot send, so say so up front rather
+        than letting the first message fail silently in Discuss."""
+        self._assert_new_sms_number_unused()
+        self.default_callerid.is_default = False
+        with self.assertRaises(ValidationError):
+            self.Channel.with_user(self.agent).connect_start_sms_channel(
+                self.NEW_SMS_NUMBER)
+        self.assertFalse(self.Channel.search([
+            ('channel_type', '=', 'connect_messages'),
+            ('connect_number', '=', self.NEW_SMS_NUMBER)]))
+
+    def test_inbound_stamps_the_line_the_customer_wrote_to(self):
+        """A conversation the customer starts runs on the line they messaged,
+        whatever the default is."""
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        # Inbound arrived on +15550000000 (see _make_incoming).
+        ch._connect_post_inbound(self._make_incoming('inbound'))
+        self.assertEqual(ch.connect_sender_number, '+15550000000')
+
+    def test_outbound_reply_stays_on_the_conversation_line(self):
+        """Replies go out on the conversation's own line, so changing the
+        default never moves a conversation already under way."""
+        from unittest.mock import patch
+
+        class _Fake:
+            sid = 'SMdef'; account_sid = 'ACtest'; messaging_service_sid = False
+            num_media = 0; error_code = None; error_message = None
+
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        ch._connect_post_inbound(self._make_incoming('inbound'))
+        with patch.object(type(self.env['connect.message']), 'client_send',
+                          return_value=_Fake()):
+            msg = ch.with_user(self.agent).message_post(
+                body='reply text', message_type='connect_message',
+                connect_provider='sms')
+        cmsg = self.env['connect.message'].search([('channel_message_id', '=', msg.id)])
+        self.assertEqual(cmsg.from_number, '+15550000000',
+                         'must reply on the line the customer wrote to')
+
+    def test_outbound_reply_on_legacy_conversation_uses_last_inbound(self):
+        """Conversations that predate the per-channel line keep replying on
+        the number the customer last messaged."""
+        from unittest.mock import patch
+
+        class _Fake:
+            sid = 'SMleg'; account_sid = 'ACtest'; messaging_service_sid = False
+            num_media = 0; error_code = None; error_message = None
+
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        ch._connect_post_inbound(self._make_incoming('inbound'))
+        # Simulate a channel created before connect_sender_number existed.
+        ch.connect_sender_number = False
+        with patch.object(type(self.env['connect.message']), 'client_send',
+                          return_value=_Fake()):
+            msg = ch.with_user(self.agent).message_post(
+                body='reply text', message_type='connect_message',
+                connect_provider='sms')
+        cmsg = self.env['connect.message'].search([('channel_message_id', '=', msg.id)])
+        self.assertEqual(cmsg.from_number, '+15550000000')
+
+    def test_start_sms_channel_uses_picked_line(self):
+        """The dialog's line is the one the new conversation runs on."""
+        second = self.env['connect.outgoing_callerid'].create({
+            'friendly_name': 'Second line', 'number': '+15558880000',
+            'callerid_type': 'number',
+        })
+        self._assert_new_sms_number_unused()
+        res = self.Channel.with_user(self.agent).connect_start_sms_channel(
+            self.NEW_SMS_NUMBER, second.number)
+        channel = self.Channel.browse(res['channel_id'])
+        self.assertEqual(channel.connect_sender_number, second.number)
+
+    def test_start_sms_channel_defaults_to_default_line(self):
+        self._assert_new_sms_number_unused()
+        res = self.Channel.with_user(self.agent).connect_start_sms_channel(
+            self.NEW_SMS_NUMBER)
+        channel = self.Channel.browse(res['channel_id'])
+        self.assertEqual(channel.connect_sender_number,
+                         self.default_callerid.number)
+
+    def test_start_sms_channel_rejects_unknown_line(self):
+        """The line comes from the browser, so it must be one we offer."""
+        with self.assertRaises(ValidationError):
+            self.Channel.with_user(self.agent).connect_start_sms_channel(
+                self.NEW_SMS_NUMBER, '+19998887777')
+
+    def test_start_sms_channel_keeps_the_line_of_an_existing_conversation(self):
+        """Resuming a conversation must not move it onto another line."""
+        second = self.env['connect.outgoing_callerid'].create({
+            'friendly_name': 'Second line', 'number': '+15558880000',
+            'callerid_type': 'number',
+        })
+        self._assert_new_sms_number_unused()
+        existing = self.Channel._get_connect_channel(
+            number=self.NEW_SMS_NUMBER, provider='sms', create_if_not_found=True)
+        existing.connect_sender_number = '+15557770000'
+        res = self.Channel.with_user(self.agent).connect_start_sms_channel(
+            self.NEW_SMS_NUMBER, second.number)
+        self.assertEqual(res['channel_id'], existing.id)
+        self.assertEqual(existing.connect_sender_number, '+15557770000')
+
+    def test_sms_sender_options_offer_twilio_numbers_only(self):
+        """Verified caller IDs are voice-only: Twilio rejects them as the From
+        of a message, so they must not be offered."""
+        self.env['connect.outgoing_callerid'].create({
+            'friendly_name': 'Personal mobile', 'number': '+15551112222',
+            'callerid_type': 'outgoing_callerid',
+        })
+        options = self.Channel.with_user(self.agent).connect_sms_sender_options()
+        numbers = [o['number'] for o in options['options']]
+        self.assertIn(self.default_callerid.number, numbers)
+        self.assertNotIn('+15551112222', numbers)
+        self.assertEqual(options['default'], self.default_callerid.number)
 
     def test_connect_sidebar_category_open_setting_persists(self):
         """The 'Messages' sidebar category needs a real res.users.settings field

--- a/connect/views/call.xml
+++ b/connect/views/call.xml
@@ -134,6 +134,9 @@
                                 </group>
                                 <group>
                                     <field name="parent_call" invisible="not parent_call"/>
+                                    <field name="park_slot" invisible="not park_slot"/>
+                                    <field name="parked_by_pbx_user" invisible="not parked_by_pbx_user"/>
+                                    <field name="parked_at" invisible="not parked_at"/>
                                     <field name="caller_pbx_user"/>
                                     <field name="called_pbx_users" widget="many2many_tags"/>
                                     <field name="answered_pbx_user"/>

--- a/connect/views/debug.xml
+++ b/connect/views/debug.xml
@@ -35,4 +35,170 @@
         </field>
     </record>
 
+    <record id="connect_call_event_action" model="ir.actions.act_window">
+      <field name="name">Call Events</field>
+      <field name="res_model">connect.call.event</field>
+      <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="connect_call_event_menu"
+              sequence="410" parent="connect_debug_menu"
+              groups="connect.group_connect_admin"
+              name="Events" action="connect_call_event_action"/>
+
+    <record id="connect_call_event_list" model="ir.ui.view">
+      <field name="name">connect.call.event.list</field>
+      <field name="model">connect.call.event</field>
+      <field name="arch" type="xml">
+        <list edit="false" create="false" delete="false" duplicate="false">
+          <field name="event_type"/>
+          <field name="call_sid"/>
+          <field name="parent_call_sid" optional="hide"/>
+          <field name="root_call_sid"/>
+          <field name="sequence_number"/>
+          <field name="state"/>
+          <field name="attempts"/>
+          <field name="next_attempt_at" optional="hide"/>
+          <field name="call_id"/>
+          <field name="channel_id"/>
+          <field name="create_date"/>
+        </list>
+      </field>
+    </record>
+
+    <record id="connect_call_event_form" model="ir.ui.view">
+      <field name="name">connect.call.event.form</field>
+      <field name="model">connect.call.event</field>
+      <field name="arch" type="xml">
+        <form edit="false" create="false" delete="false" duplicate="false">
+          <sheet>
+            <group>
+              <group>
+                <field name="event_type"/>
+                <field name="dedup_key"/>
+                <field name="idempotency_token"/>
+                <field name="state"/>
+                <field name="attempts"/>
+                <field name="next_attempt_at"/>
+              </group>
+              <group>
+                <field name="call_sid"/>
+                <field name="parent_call_sid"/>
+                <field name="root_call_sid"/>
+                <field name="sequence_number"/>
+                <field name="event_timestamp"/>
+                <field name="call_id"/>
+                <field name="channel_id"/>
+              </group>
+            </group>
+            <group string="Post-commit command">
+              <field name="command_type"/>
+              <field name="command_state"/>
+              <field name="command_attempts"/>
+              <field name="command_payload"/>
+            </group>
+            <group string="Error">
+              <field name="error_message" nolabel="1"/>
+            </group>
+            <group string="Payload">
+              <field name="payload" nolabel="1"/>
+            </group>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <record id="connect_call_event_search" model="ir.ui.view">
+      <field name="name">connect.call.event.search</field>
+      <field name="model">connect.call.event</field>
+      <field name="arch" type="xml">
+        <search>
+          <field name="call_sid"/>
+          <field name="parent_call_sid"/>
+          <field name="root_call_sid"/>
+          <field name="dedup_key"/>
+          <field name="call_id"/>
+          <filter name="pending" string="Pending" domain="[('state', '=', 'pending')]"/>
+          <filter name="errors" string="Errors" domain="[('state', '=', 'error')]"/>
+          <filter name="group_state" string="State" context="{'group_by': 'state'}"/>
+          <filter name="group_type" string="Type" context="{'group_by': 'event_type'}"/>
+        </search>
+      </field>
+    </record>
+
+    <record id="connect_call_attempt_action" model="ir.actions.act_window">
+      <field name="name">Call Attempts</field>
+      <field name="res_model">connect.call.attempt</field>
+      <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="connect_call_attempt_menu"
+              sequence="420" parent="connect_debug_menu"
+              groups="connect.group_connect_admin"
+              name="Call Attempts" action="connect_call_attempt_action"/>
+
+    <record id="connect_call_attempt_list" model="ir.ui.view">
+      <field name="name">connect.call.attempt.list</field>
+      <field name="model">connect.call.attempt</field>
+      <field name="arch" type="xml">
+        <list edit="false" create="false" delete="false" duplicate="false">
+          <field name="kind"/>
+          <field name="call_id"/>
+          <field name="parent_sid"/>
+          <field name="dial_call_sid"/>
+          <field name="external_sid"/>
+          <field name="target_user_id"/>
+          <field name="expected_count"/>
+          <field name="state"/>
+          <field name="expires_at"/>
+        </list>
+      </field>
+    </record>
+
+    <record id="connect_call_attempt_form" model="ir.ui.view">
+      <field name="name">connect.call.attempt.form</field>
+      <field name="model">connect.call.attempt</field>
+      <field name="arch" type="xml">
+        <form edit="false" create="false" delete="false" duplicate="false">
+          <sheet>
+            <group>
+              <group>
+                <field name="kind"/>
+                <field name="call_id"/>
+                <field name="target_user_id"/>
+                <field name="expected_count"/>
+              </group>
+              <group>
+                <field name="parent_sid"/>
+                <field name="dial_call_sid"/>
+                <field name="external_sid"/>
+                <field name="state"/>
+                <field name="expires_at"/>
+                <field name="resolved_at"/>
+              </group>
+            </group>
+            <group string="Context">
+              <field name="context" nolabel="1"/>
+            </group>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <record id="connect_call_attempt_search" model="ir.ui.view">
+      <field name="name">connect.call.attempt.search</field>
+      <field name="model">connect.call.attempt</field>
+      <field name="arch" type="xml">
+        <search>
+          <field name="parent_sid"/>
+          <field name="dial_call_sid"/>
+          <field name="external_sid"/>
+          <field name="call_id"/>
+          <filter name="pending" string="Pending" domain="[('state', '=', 'pending')]"/>
+          <filter name="group_state" string="State" context="{'group_by': 'state'}"/>
+          <filter name="group_kind" string="Kind" context="{'group_by': 'kind'}"/>
+        </search>
+      </field>
+    </record>
+
 </odoo>

--- a/connect/views/settings.xml
+++ b/connect/views/settings.xml
@@ -67,6 +67,8 @@
                       <small colspan="2">If you disable it remove the HTTP AUTH in Twilio. Read <a target="new" href="https://help.twilio.com/articles/15827821586843">more</a>.</small>
                       <field name="fetch_call_prices"/>
                       <small colspan="2">Fetch call prices from Twilio API after call completion. This may add delay to call processing.</small>
+                      <field name="delete_processed_call_events"/>
+                      <small colspan="2">Disable to retain successfully processed call events and runtime attempts for one hour in Debug.</small>
                     </group>
                     <group>
                       <button colspan="2" name="reformat_numbers_button" string="FORMAT NUMBERS" type="object"/>

--- a/connect/wizard/transfer.py
+++ b/connect/wizard/transfer.py
@@ -631,52 +631,7 @@ class CallForwardHandler(models.TransientModel):
 
     @api.model
     def handle_transfer_continuation(self, webhook_params):
-        """
-        Handle the action callback from transfer dial completion.
-        For successful transfers, update completion status.
-        For failed transfers, route the external caller to the transfer target's voicemail.
-        """
-        call_sid = webhook_params.get('CallSid')
-        dial_call_status = webhook_params.get('DialCallStatus')
-        dial_call_sid = webhook_params.get('DialCallSid')
-        
-        # Find the call record
-        call_channel = self.env['connect.channel'].sudo().search([('sid', '=', call_sid)], limit=1)
-        if not call_channel or not call_channel.call:
-            logger.warning(f'Could not find call for transfer continuation: {call_sid}')
-            response = VoiceResponse()
-            response.hangup()
-            return response
-        
-        call = call_channel.call
-        
-        # If transfer recipient answered (DialCallStatus: completed), update completion status
-        if dial_call_status == 'completed' and call.transferred_users:
-            # Find the transfer recipient who answered by looking at transfer context
-            transfer_context = call.transfer_context or {}
-            transfer_recipient_login = None
-            
-            # Look for the transfer recipient in the context using call SID or dial call SID
-            for context_key, context_value in transfer_context.items():
-                if context_key.startswith('_'):  # Skip internal keys like _external_leg
-                    continue
-                if context_key in (call_sid, dial_call_sid):
-                    if isinstance(context_value, dict) and 'user_id' in context_value:
-                        transfer_recipient_login = context_value.get('user_login')
-                        break
-            
-            if transfer_recipient_login:
-                # Find the user and set as completed_by_user
-                transfer_recipient = self.env['res.users'].sudo().search([('login', '=', transfer_recipient_login)], limit=1)
-                if transfer_recipient:
-                    call.completed_by_user = transfer_recipient
-                else:
-                    logger.warning(f'Could not find user with login {transfer_recipient_login}')
-            else:
-                # Fallback: use the first transfer recipient
-                if call.transferred_users:
-                    call.completed_by_user = call.transferred_users[0]
-        
+        """Return TwiML immediately; the inbox projects transfer state."""
         response = VoiceResponse()
         response.hangup()
         return response


### PR DESCRIPTION
The `connect` module has been developed out-of-tree in the Mirage-Pools deployment repo since 2.0.3 and has drifted to 2.0.6 there. This lands that work upstream.

`connect/` is taken **verbatim** from the vendored copy — `git diff mirage/connect -- connect` is empty — so this is exactly the tree currently running in the `connect` environment (`oduflow_1_connect`, Odoo 19).

## What lands

| | |
|---|---|
| `models/call_event.py` | +1090 — `connect.call.event` webhook projection queue (grouped events, savepoint per group, defer/retry) |
| `models/call_attempt.py` | +86 — `connect.call.attempt`, kinds `direct_call` / `ring_group` / `transfer` / `external_leg` / `external_termination` |
| `models/channel.py` | +176 — `UNIQUE(sid)` constraint plus the `_auto_init` dedup that makes it applicable |
| `models/discuss_channel.py` | +188 — Discuss messaging work, New SMS dialog backend |
| `static/src/core/web/new_sms_dialog.*`, `static/src/core/public_web/discuss_search_patch.*` | new — New SMS dialog, Discuss search patch |
| `tests/test_call_event.py`, `tests/test_call_parking.py` | +372 — projection queue and call parking coverage |
| `migrations/2.0.6/post-migrate.py` | new — backfills `finalized_at` and `connect.call.attempt` for in-flight legacy calls |

34 files, +3196 / −462.

## Why the SID constraint needs the `_auto_init` hook

`connect.channel._sid_unique` (`UNIQUE(sid)`) cannot be created on a database that already holds duplicate SIDs — Postgres refuses the index, `odoo.schema` logs an ERROR, and **the upgrade still exits 0**, so the constraint ends up silently absent while `ir_model_constraint` claims it exists. Real databases do hold such duplicates: the `connect` environment had 33 pairs, created 5–30 ms apart by concurrent Twilio webhooks (one leg `ringing`, one `no-answer`).

The dedup therefore runs from `connect.channel._auto_init()`, immediately before `super()` reaches `_add_sql_constraints()`. It deliberately does **not** live in a migration folder: we tried that twice in the deployment repo and both times an unrelated manifest bump moved the version past the folder before it landed, so the scripts were skipped and the constraint stayed missing. `init()` is the documented hook but runs *after* the constraint has already been refused. The ranked columns are probed with `sql.column_exists`, and the whole thing early-returns once no duplicate is left.

Verified on the `connect` environment: `Merged 33 duplicate channel SID(s)`, duplicates 33 → 0, channels 96 612 → 96 579, `connect_channel_sid_unique` created, 0 dangling `parent_channel`, calls without `finalized_at` 17 839 → 0, `/web/health` → `{"status": "pass"}`.

The constraint is safe against the residual webhook race precisely *because* of the queue in this PR: an `IntegrityError` is caught by the savepoint in `connect.call.event._process_events`, the group is deferred, and the retry finds the existing channel and writes to it.

## Needs a maintainer ack before merge

Six methods present on `19.0` are **not** in the vendored tree — the pre-queue transfer / external-termination webhook path, which the `transfer`, `external_leg` and `external_termination` attempt kinds replace:

- `controllers/main.py`: `_process_extension_redirect_completion`, `_store_external_call_termination_context`, `_terminate_external_call_after_transfer_completion`, `_create_or_update_transfer_channel`
- `models/call.py`: `_cleanup_old_webhook_expectations`
- `models/channel.py`: `_handle_external_call_termination_on_hangup`

Nothing outside `connect/` references them, and `migrations/2.0.6/post-migrate.py` migrates the old `transfer_context` entries into attempt records — so the replacement looks deliberate and complete. Please confirm that reading before merging; that is the only judgement call in this sync.

Audited for the reverse direction as well: no file on `19.0` is missing from the vendored tree, and no other method exists upstream but not here. `connect_create_partner` and the reply-from-last-inbound-line logic are both present (they only moved within the file).