### PR TITLE
[15.0] Backport current messaging features without WebRTC

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Connect",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "author": "Oduist",
     "maintainer": "Oduist",
     "live_test_url": "https://connect-demo.oduist.com/",
@@ -33,6 +33,7 @@
         "security/license.xml",
         "security/user_record_rules.xml",
         "security/admin_record_rules.xml",
+        "security/discuss_messages.xml",
         # Views
         "views/menu.xml",
         "views/settings.xml",
@@ -79,10 +80,12 @@
             "/connect/static/src/services/actions/*",
             # "/connect/static/src/services/active_calls/*",
             # "/connect/static/src/services/mail/*",
-            "/connect/static/src/core/common/*",
+            "/connect/static/src/mail15/*.js",
+            "/connect/static/src/mail15/*.scss",
         ],
         "web.assets_qweb": [
             "connect/static/src/components/license_banner/*.xml",
+            "connect/static/src/mail15/*.xml",
         ],
     },
     "post_init_hook": "post_init_hook",

--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Connect",
-    "version": "2.0.3",
+    "version": "15.0.2.0.3",
     "author": "Oduist",
     "maintainer": "Oduist",
     "live_test_url": "https://connect-demo.oduist.com/",

--- a/connect/controllers/main.py
+++ b/connect/controllers/main.py
@@ -14,9 +14,22 @@ from odoo.api import SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.addons.connect.models import s3_utils
 
+if release.version_info[0] < 17:
+    from odoo.addons.mail.controllers.discuss import DiscussController
+
 logger = logging.getLogger(__name__)
 
 route_type = "json" if release.version_info[0] < 19.0 else 'jsonrpc'
+
+
+if release.version_info[0] < 17:
+    class ConnectDiscussController(DiscussController):
+        """Allow Connect metadata through the Odoo 15 message-post route."""
+
+        def _get_allowed_message_post_params(self):
+            return super()._get_allowed_message_post_params() | {
+                'connect_provider', 'connect_sender_id',
+            }
 
 class ConnectController(http.Controller):
 

--- a/connect/models/__init__.py
+++ b/connect/models/__init__.py
@@ -13,6 +13,8 @@ from . import call
 from . import callflow
 from . import ir_module_module
 from . import channel
+from . import discuss_channel
+from . import discuss_channel_member
 from . import debug
 from . import domain
 from . import exten

--- a/connect/models/call.py
+++ b/connect/models/call.py
@@ -204,7 +204,10 @@ class Call(models.Model):
         # overrides to keep the stored flag in sync (e.g. on "mark done").
         calls = self.exists()
         if calls:
-            calls.invalidate_cache(['activity_ids'], calls.ids)
+            if release.version_info[0] >= 17:
+                calls.invalidate_recordset(['activity_ids'])
+            else:
+                calls.invalidate_cache(['activity_ids'], calls.ids)
             calls._compute_has_activity()
 
     def _get_voicemail_widget(self):
@@ -1428,6 +1431,9 @@ class Call(models.Model):
         api_url = self.env['connect.settings'].sudo().get_param("api_url")
         edge = self.env["connect.settings"].get_param("twilio_edge")
         status_url = urljoin(api_url, "twilio/webhook/callstatus#e={}".format(edge))
+        record_status_url = urljoin(
+            api_url, "twilio/webhook/recordingstatus#e={}".format(edge)
+        )
         if exten:
             callerId = user.connect_user.exten.number
             twiml = exten.render()
@@ -1455,11 +1461,15 @@ class Call(models.Model):
                     callerId = user.connect_user.outgoing_callerid.number
                 else:
                     callerId = default_number.number
-                twiml = self.env['connect.settings'].get_external_call_route(number, callerId, status_url)
+                dial_record = (
+                    'record-from-answer-dual'
+                    if self.env.user.connect_user.record_calls
+                    else 'do-not-record'
+                )
+                twiml = self.env['connect.settings'].get_external_call_route(
+                    number, callerId, status_url,
+                    record=dial_record, record_status_url=record_status_url)
         record = self.env.user.connect_user.record_calls
-        record_status_url = urljoin(
-            api_url, "twilio/webhook/recordingstatus#e={}".format(edge)
-        )
         debug(self, "Originate destination TwiML: {}".format(twiml))
         channel = client.calls.create(
             twiml=twiml,

--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -153,6 +153,24 @@ class CallFlow(models.Model):
             else:
                 dial = Dial(callerId=callerId, action=action_url, timeout=self.ring_timeout,
                         referUrl=refer_url)
+            # This enriches WebRTC client legs on modern versions only. The
+            # Odoo 15 package deliberately keeps the web phone disabled.
+            if release.version_info[0] >= 17:
+                channel = self.env['connect.channel'].sudo().search(
+                    [('sid', '=', request.get('CallSid'))], limit=1)
+                call = channel.call if channel else None
+                raw_caller = request.get('Caller') or ''
+                if call and call.partner:
+                    caller_partner = call.partner
+                elif channel and channel.caller_user:
+                    caller_partner = channel.caller_user.partner_id
+                elif raw_caller.startswith('+'):
+                    caller_partner = self.env['res.partner'].sudo().get_partner_by_number(
+                        raw_caller)
+                else:
+                    caller_partner = self.env['res.partner']
+                caller_partner_id = caller_partner.id if caller_partner else False
+                caller_name = caller_partner.name if caller_partner else False
             for user in self.ring_users:
                 callflows = self.env['connect.user_callflow'].sudo().search(
                     [('callflow_type', 'in', ['sip', 'client']), ('user', '=', user.id)], order='prio')
@@ -166,7 +184,12 @@ class CallFlow(models.Model):
                             statusCallbackEvent='answered completed',
                             statusCallback=status_url)
                         client.identity(user.get_client_identity())
-                        client.parameter(name='CallerName', value=callerId)
+                        if release.version_info[0] >= 17:
+                            if caller_name:
+                                client.parameter(name='CallerName', value=caller_name)
+                            client.parameter(name='Partner', value=caller_partner_id)
+                        else:
+                            client.parameter(name='CallerName', value=callerId)
                         dial.append(client)
             response.append(dial)
         else:

--- a/connect/models/discuss_channel.py
+++ b/connect/models/discuss_channel.py
@@ -89,7 +89,14 @@ class DiscussChannel(models.Model):
                     for partner in members
                 ],
             }
-        return {'channel_partner_ids': [Command.set(members.ids)]}
+        # Odoo 15's ``mail.channel.create`` expands command 6 incorrectly into
+        # a nested list before de-duplicating the partner IDs.  Link commands
+        # are the supported equivalent for this legacy API.
+        return {
+            'channel_partner_ids': [
+                Command.link(partner_id) for partner_id in members.ids
+            ],
+        }
 
     def _connect_member_partners(self):
         self.ensure_one()

--- a/connect/models/discuss_channel.py
+++ b/connect/models/discuss_channel.py
@@ -1,0 +1,420 @@
+# -*- coding: utf-8 -*-
+import base64
+import logging
+from datetime import timedelta
+
+from markupsafe import Markup
+
+from odoo import api, Command, fields, models, release
+from odoo.exceptions import ValidationError
+from odoo.tools import file_open, html2plaintext
+
+if release.version_info[0] >= 17:
+    from odoo.addons.mail.tools.discuss import Store
+
+logger = logging.getLogger(__name__)
+
+CHANNEL_MODEL = 'discuss.channel' if release.version_info[0] >= 17 else 'mail.channel'
+
+
+class DiscussChannel(models.Model):
+    """Customer messaging channel shared by Odoo 15 and modern Discuss.
+
+    Odoo 15 still calls the model ``mail.channel`` and serializes it through
+    ``channel_info``. Odoo 17+ calls it ``discuss.channel`` and uses ``Store``.
+    The feature logic remains common; only the transport/member APIs branch.
+    """
+
+    _inherit = CHANNEL_MODEL
+
+    channel_type = fields.Selection(
+        selection_add=[('connect_messages', 'Customer Messages')],
+        ondelete={'connect_messages': 'cascade'},
+    )
+    connect_partner_id = fields.Many2one(
+        'res.partner', string='Customer', index=True)
+    connect_number = fields.Char(string='Customer Number')
+    connect_channel_provider = fields.Char(
+        string='Channel Provider', default='sms')
+    connect_last_inbound_whatsapp_id = fields.Many2one('mail.message')
+    connect_whatsapp_valid_until = fields.Datetime(
+        compute='_compute_connect_whatsapp_window')
+    connect_whatsapp_window_open = fields.Boolean(
+        compute='_compute_connect_whatsapp_window')
+
+    @api.depends(
+        'connect_last_inbound_whatsapp_id',
+        'connect_last_inbound_whatsapp_id.create_date',
+    )
+    def _compute_connect_whatsapp_window(self):
+        now = fields.Datetime.now()
+        for channel in self:
+            last = channel.connect_last_inbound_whatsapp_id
+            if channel.channel_type == 'connect_messages' and last:
+                channel.connect_whatsapp_valid_until = (
+                    last.create_date + timedelta(hours=24))
+                channel.connect_whatsapp_window_open = (
+                    channel.connect_whatsapp_valid_until > now)
+            else:
+                channel.connect_whatsapp_valid_until = False
+                channel.connect_whatsapp_window_open = False
+
+    @api.model
+    def _connect_agent_partners(self):
+        admin_group = self.env.ref(
+            'connect.group_connect_admin', raise_if_not_found=False)
+        user_group = self.env.ref(
+            'connect.group_connect_user', raise_if_not_found=False)
+        groups = (admin_group | user_group).filtered(bool)
+        if not groups:
+            return self.env['res.partner']
+        group_field = 'all_group_ids' if release.version_info[0] >= 18 else 'groups_id'
+        users = self.env['res.users'].sudo().search([
+            (group_field, 'in', groups.ids),
+        ])
+        return users.partner_id
+
+    @staticmethod
+    def _connect_parse_number(number):
+        if (number or '').startswith('whatsapp:'):
+            return number[len('whatsapp:'):], 'whatsapp'
+        return number or '', 'sms'
+
+    @api.model
+    def _connect_member_create_values(self, members):
+        if release.version_info[0] >= 17:
+            return {
+                'channel_member_ids': [
+                    Command.create({'partner_id': partner.id})
+                    for partner in members
+                ],
+            }
+        return {'channel_partner_ids': [Command.set(members.ids)]}
+
+    def _connect_member_partners(self):
+        self.ensure_one()
+        if release.version_info[0] >= 17:
+            return self.channel_member_ids.partner_id
+        return self.channel_last_seen_partner_ids.partner_id
+
+    def _get_connect_channel(
+        self, partner=False, number=False, provider='sms',
+        create_if_not_found=False,
+    ):
+        clean_number = self._connect_parse_number(number)[0]
+        if partner:
+            channel = self.sudo().search([
+                ('channel_type', '=', 'connect_messages'),
+                ('connect_partner_id', '=', partner.id),
+            ], limit=1)
+            if channel:
+                vals = {}
+                if clean_number and channel.connect_number != clean_number:
+                    vals['connect_number'] = clean_number
+                if provider and channel.connect_channel_provider != provider:
+                    vals['connect_channel_provider'] = provider
+                if vals:
+                    channel.write(vals)
+                return channel
+            if not create_if_not_found:
+                return self.browse()
+            members = self._connect_agent_partners() | partner
+            vals = {
+                'name': partner.display_name,
+                'channel_type': 'connect_messages',
+                'connect_partner_id': partner.id,
+                'connect_number': clean_number or partner.phone_sanitized,
+                'connect_channel_provider': provider,
+            }
+            if release.version_info[0] < 17:
+                vals['public'] = 'private'
+            vals.update(self._connect_member_create_values(members))
+            return self.sudo().with_context(mail_create_nosubscribe=True).create(vals)
+        if clean_number:
+            channel = self.sudo().search([
+                ('channel_type', '=', 'connect_messages'),
+                ('connect_partner_id', '=', False),
+                ('connect_number', '=', clean_number),
+            ], limit=1)
+            if channel:
+                return channel
+            if not create_if_not_found:
+                return self.browse()
+            members = self._connect_agent_partners()
+            vals = {
+                'name': clean_number,
+                'channel_type': 'connect_messages',
+                'connect_partner_id': False,
+                'connect_number': clean_number,
+                'connect_channel_provider': provider,
+            }
+            if release.version_info[0] < 17:
+                vals['public'] = 'private'
+            vals.update(self._connect_member_create_values(members))
+            return self.sudo().with_context(mail_create_nosubscribe=True).create(vals)
+        return self.browse()
+
+    def connect_create_partner(self, partner_name=None):
+        self.ensure_one()
+        if self.channel_type != 'connect_messages':
+            raise ValidationError('Not a Connect Messages channel')
+        if self.connect_partner_id:
+            raise ValidationError('Channel already has a contact')
+        if not self.connect_number:
+            raise ValidationError('Channel has no phone number')
+        default_image = False
+        try:
+            with file_open('mail/static/src/img/smiley/avatar.jpg', 'rb') as stream:
+                default_image = base64.b64encode(stream.read())
+        except Exception:
+            logger.warning('Could not read default contact avatar', exc_info=True)
+        partner = self.env['res.partner'].sudo().create({
+            'name': partner_name or self.connect_number,
+            'phone': self.connect_number,
+            'image_1920': default_image or False,
+        })
+        self._connect_link_partner(partner)
+        return {'partner_id': partner.id, 'partner_name': partner.display_name}
+
+    def _connect_link_partner(self, partner):
+        self.ensure_one()
+        self.sudo().write({
+            'connect_partner_id': partner.id,
+            'name': partner.display_name,
+        })
+        if partner not in self._connect_member_partners():
+            if release.version_info[0] >= 17:
+                self.sudo().write({
+                    'channel_member_ids': [
+                        Command.create({'partner_id': partner.id}),
+                    ],
+                })
+            else:
+                self.sudo().write({
+                    'channel_partner_ids': [Command.link(partner.id)],
+                })
+        self.env['connect.message'].sudo().search([
+            ('from_number', '=', self.connect_number),
+            ('partner', '=', False),
+        ]).write({'partner': partner.id})
+
+    def _connect_message_body(self, connect_message):
+        body_text = connect_message.body or ''
+        if connect_message.media_url:
+            return Markup(
+                "<div class='d-flex flex-column'><span>{}</span>{}</div>"
+            ).format(body_text, connect_message.media_widget)
+        return Markup('<span>{}</span>').format(body_text)
+
+    def _connect_post_inbound(self, connect_message, parent_id=False):
+        self.ensure_one()
+        partner = connect_message.partner
+        if partner:
+            author_vals = {'author_id': partner.id}
+        else:
+            author_vals = {
+                'author_id': False,
+                'email_from': self.connect_number or connect_message.from_number,
+            }
+        post_kwargs = {
+            'body': self._connect_message_body(connect_message),
+            'message_type': 'connect_message',
+            'subtype_xmlid': 'mail.mt_comment',
+            **author_vals,
+        }
+        if parent_id:
+            post_kwargs['parent_id'] = parent_id
+        message = self.sudo().with_context(connect_mirror=True).message_post(
+            **post_kwargs)
+        connect_message.write({
+            'channel_id': self.id,
+            'channel_message_id': message.id,
+        })
+        message.connect_message = connect_message.id
+        if connect_message.message_type == 'whatsapp':
+            self.connect_last_inbound_whatsapp_id = message.id
+        self._connect_resurface()
+        return message
+
+    def _connect_post_outbound(self, connect_message):
+        self.ensure_one()
+        author = (
+            connect_message.sender_user.partner_id
+            or self.env.user.partner_id
+        )
+        message = self.sudo().with_context(connect_mirror=True).message_post(
+            body=self._connect_message_body(connect_message),
+            message_type='connect_message',
+            subtype_xmlid='mail.mt_comment',
+            author_id=author.id,
+        )
+        connect_message.write({
+            'channel_id': self.id,
+            'channel_message_id': message.id,
+        })
+        message.connect_message = connect_message.id
+        self._connect_resurface()
+        return message
+
+    def _connect_resurface(self):
+        self.ensure_one()
+        if release.version_info[0] >= 17:
+            archived = self.channel_member_ids.filtered(lambda member: not member.is_pinned)
+            if not archived:
+                return
+            archived.write({'unpin_dt': False})
+            for member in archived:
+                user = member.partner_id.user_ids[:1]
+                if user:
+                    Store(bus_channel=user).add(self.with_user(user)).bus_send()
+            return
+
+        archived = self.channel_last_seen_partner_ids.filtered(
+            lambda member: not member.is_pinned)
+        if not archived:
+            return
+        archived.write({
+            'is_pinned': True,
+            'last_interest_dt': fields.Datetime.now(),
+        })
+        for member in archived:
+            user = member.partner_id.user_ids[:1]
+            if user:
+                info = self.with_user(user).sudo().channel_info()[0]
+                self.env['bus.bus'].sudo()._sendone(
+                    member.partner_id,
+                    'mail.channel/legacy_insert',
+                    info,
+                )
+
+    if release.version_info[0] >= 17:
+        def _get_allowed_message_params(self):
+            return super()._get_allowed_message_params() | {
+                'connect_provider', 'connect_sender_id',
+            }
+
+    def message_post(self, *args, **kwargs):
+        connect_provider = kwargs.pop('connect_provider', None)
+        connect_sender_id = kwargs.pop('connect_sender_id', None)
+        is_outbound = (
+            self.channel_type == 'connect_messages'
+            and kwargs.get('message_type') == 'connect_message'
+            and kwargs.get('subtype_xmlid') != 'mail.mt_note'
+            and not self.env.context.get('connect_mirror')
+        )
+        message = super().message_post(*args, **kwargs)
+        if is_outbound and message:
+            self._connect_send_outbound(
+                message, connect_provider, connect_sender_id)
+        return message
+
+    def _connect_recipient(self):
+        self.ensure_one()
+        return self.connect_number or self.connect_partner_id.phone_sanitized
+
+    def _connect_send_outbound(self, message, provider, sender_id):
+        self.ensure_one()
+        partner = self.connect_partner_id
+        recipient = self._connect_recipient()
+        if not recipient:
+            raise ValidationError('Channel has no recipient phone number')
+        body = html2plaintext(message.body) if message.body else ''
+        provider = provider or self.connect_channel_provider or 'sms'
+        res_id = partner.id or None
+        res_model = 'res.partner' if res_id else None
+        last_inbound = self.env['connect.message'].sudo().search([
+            ('channel_id', '=', self.id),
+            ('status', '=', 'received'),
+        ], order='create_date desc', limit=1)
+        if provider == 'whatsapp':
+            sender_model = self.env['connect.whatsapp_sender']
+            if sender_id:
+                whatsapp_sender = sender_model.sudo().browse(int(sender_id))
+            elif last_inbound:
+                whatsapp_sender = sender_model.sudo().search([
+                    ('number', '=', last_inbound.to_number),
+                ], limit=1)
+                if not whatsapp_sender:
+                    whatsapp_sender = sender_model.get_default_sender(self.env.user)
+            else:
+                whatsapp_sender = sender_model.get_default_sender(self.env.user)
+            if not whatsapp_sender:
+                raise ValidationError('No WhatsApp sender is configured')
+            connect_message = whatsapp_sender.send_whatsapp(
+                recipient=recipient,
+                body=body,
+                res_model=res_model,
+                res_id=res_id,
+                raise_on_error=True,
+                skip_chatter=True,
+            )
+        else:
+            caller_id = sender_id or None
+            if not caller_id and last_inbound:
+                caller_id = last_inbound.to_number or None
+            connect_message = self.env['connect.message'].send(
+                recipient,
+                body,
+                res_id=res_id,
+                res_model=res_model,
+                outgoing_callerid=caller_id,
+                media_urls=self._connect_media_urls(message),
+                skip_chatter=True,
+            )
+        if connect_message:
+            connect_message.sudo().write({
+                'channel_message_id': message.id,
+                'channel_id': self.id,
+            })
+            message.sudo().connect_message = connect_message.id
+        return connect_message
+
+    def _connect_media_urls(self, message):
+        urls = []
+        base_url = (
+            self.env['connect.settings'].sudo().get_param('api_url')
+            or self.get_base_url()
+        )
+        for attachment in message.attachment_ids:
+            token = attachment.sudo().generate_access_token()[0]
+            urls.append('%s/web/content/%d?access_token=%s&download=true' % (
+                base_url.rstrip('/'), attachment.id, token,
+            ))
+        return urls
+
+    if release.version_info[0] >= 17:
+        def _to_store(self, store, *args, **kwargs):
+            super()._to_store(store, *args, **kwargs)
+            for channel in self.filtered(
+                    lambda rec: rec.channel_type == 'connect_messages'):
+                store.add_records_fields(channel, {
+                    'connect_whatsapp_window_open': (
+                        channel.connect_whatsapp_window_open),
+                    'connect_whatsapp_valid_until': (
+                        channel.connect_whatsapp_valid_until),
+                    'connect_partner_id': channel.connect_partner_id.id or False,
+                    'connect_number': channel.connect_number,
+                    'connect_channel_provider': (
+                        channel.connect_channel_provider or 'sms'),
+                })
+    else:
+        def channel_info(self):
+            info_list = super().channel_info()
+            channels = {channel.id: channel for channel in self}
+            for info in info_list:
+                channel = channels.get(info['id'])
+                if channel and channel.channel_type == 'connect_messages':
+                    info.update({
+                        'connect_whatsapp_window_open': (
+                            channel.connect_whatsapp_window_open),
+                        'connect_whatsapp_valid_until': (
+                            fields.Datetime.to_string(
+                                channel.connect_whatsapp_valid_until)
+                            if channel.connect_whatsapp_valid_until else False),
+                        'connect_partner_id': (
+                            channel.connect_partner_id.id or False),
+                        'connect_number': channel.connect_number,
+                        'connect_channel_provider': (
+                            channel.connect_channel_provider or 'sms'),
+                    })
+            return info_list

--- a/connect/models/discuss_channel.py
+++ b/connect/models/discuss_channel.py
@@ -18,85 +18,75 @@ CHANNEL_MODEL = 'discuss.channel' if release.version_info[0] >= 17 else 'mail.ch
 
 
 class DiscussChannel(models.Model):
-    """Customer messaging channel shared by Odoo 15 and modern Discuss.
-
-    Odoo 15 still calls the model ``mail.channel`` and serializes it through
-    ``channel_info``. Odoo 17+ calls it ``discuss.channel`` and uses ``Store``.
-    The feature logic remains common; only the transport/member APIs branch.
-    """
-
     _inherit = CHANNEL_MODEL
 
     channel_type = fields.Selection(
         selection_add=[('connect_messages', 'Customer Messages')],
         ondelete={'connect_messages': 'cascade'},
     )
+    # The customer this conversation belongs to (one channel per partner).
     connect_partner_id = fields.Many2one(
-        'res.partner', string='Customer', index=True)
+        'res.partner', string='Customer',
+        index='btree_not_null' if release.version_info[0] >= 17 else True)
+    # Phone number we last spoke to the customer on; default reply target.
     connect_number = fields.Char(string='Customer Number')
-    connect_channel_provider = fields.Char(
-        string='Channel Provider', default='sms')
+    # Messaging provider used to reach this customer ('sms' or 'whatsapp').
+    connect_channel_provider = fields.Char(string='Channel Provider', default='sms')
+    # WhatsApp 24h session window (per Twilio/Meta), WhatsApp messages only.
     connect_last_inbound_whatsapp_id = fields.Many2one('mail.message')
     connect_whatsapp_valid_until = fields.Datetime(
         compute='_compute_connect_whatsapp_window')
     connect_whatsapp_window_open = fields.Boolean(
         compute='_compute_connect_whatsapp_window')
 
-    @api.depends(
-        'connect_last_inbound_whatsapp_id',
-        'connect_last_inbound_whatsapp_id.create_date',
-    )
+    @api.depends('connect_last_inbound_whatsapp_id',
+                 'connect_last_inbound_whatsapp_id.create_date')
     def _compute_connect_whatsapp_window(self):
         now = fields.Datetime.now()
         for channel in self:
             last = channel.connect_last_inbound_whatsapp_id
             if channel.channel_type == 'connect_messages' and last:
-                channel.connect_whatsapp_valid_until = (
-                    last.create_date + timedelta(hours=24))
-                channel.connect_whatsapp_window_open = (
-                    channel.connect_whatsapp_valid_until > now)
+                channel.connect_whatsapp_valid_until = last.create_date + timedelta(hours=24)
+                channel.connect_whatsapp_window_open = channel.connect_whatsapp_valid_until > now
             else:
                 channel.connect_whatsapp_valid_until = False
                 channel.connect_whatsapp_window_open = False
 
     @api.model
     def _connect_agent_partners(self):
-        admin_group = self.env.ref(
-            'connect.group_connect_admin', raise_if_not_found=False)
-        user_group = self.env.ref(
-            'connect.group_connect_user', raise_if_not_found=False)
+        admin_group = self.env.ref('connect.group_connect_admin', raise_if_not_found=False)
+        user_group = self.env.ref('connect.group_connect_user', raise_if_not_found=False)
         groups = (admin_group | user_group).filtered(bool)
         if not groups:
             return self.env['res.partner']
         group_field = 'all_group_ids' if release.version_info[0] >= 18 else 'groups_id'
-        users = self.env['res.users'].sudo().search([
-            (group_field, 'in', groups.ids),
-        ])
+        users = self.env['res.users'].sudo().search([(group_field, 'in', groups.ids)])
         return users.partner_id
 
     @staticmethod
     def _connect_parse_number(number):
+        """Strip provider prefix and return (clean_number, provider)."""
         if (number or '').startswith('whatsapp:'):
             return number[len('whatsapp:'):], 'whatsapp'
         return number or '', 'sms'
 
     @api.model
-    def _connect_member_create_values(self, members):
+    def _connect_create_channel(self, values, members):
         if release.version_info[0] >= 17:
-            return {
-                'channel_member_ids': [
-                    Command.create({'partner_id': partner.id})
-                    for partner in members
+            values['channel_member_ids'] = [
+                Command.create({'partner_id': partner.id}) for partner in members
+            ]
+        else:
+            values.update({
+                'public': 'private',
+                # Odoo 15 mail.channel.create() only handles link commands
+                # correctly; its command-6 expansion produces a nested list.
+                'channel_partner_ids': [
+                    Command.link(partner_id) for partner_id in members.ids
                 ],
-            }
-        # Odoo 15's ``mail.channel.create`` expands command 6 incorrectly into
-        # a nested list before de-duplicating the partner IDs.  Link commands
-        # are the supported equivalent for this legacy API.
-        return {
-            'channel_partner_ids': [
-                Command.link(partner_id) for partner_id in members.ids
-            ],
-        }
+            })
+        return self.sudo().with_context(
+            mail_create_nosubscribe=True).create(values)
 
     def _connect_member_partners(self):
         self.ensure_one()
@@ -104,40 +94,37 @@ class DiscussChannel(models.Model):
             return self.channel_member_ids.partner_id
         return self.channel_last_seen_partner_ids.partner_id
 
-    def _get_connect_channel(
-        self, partner=False, number=False, provider='sms',
-        create_if_not_found=False,
-    ):
-        clean_number = self._connect_parse_number(number)[0]
+    def _get_connect_channel(self, partner=False, number=False, provider='sms', create_if_not_found=False):
+        """Find-or-create a connect_messages channel.
+
+        When partner is given the channel is keyed on the partner.
+        When only number is given (no partner) the channel is keyed on the phone number.
+        ``number`` must be a clean E.164 string (no provider prefix).
+        ``provider`` ('sms' or 'whatsapp') is passed explicitly by the caller, never parsed
+        from the number.
+        """
+        clean_number = self._connect_parse_number(number)[0]  # defensive strip; provider is passed explicitly
         if partner:
             channel = self.sudo().search([
                 ('channel_type', '=', 'connect_messages'),
                 ('connect_partner_id', '=', partner.id),
             ], limit=1)
             if channel:
-                vals = {}
                 if clean_number and channel.connect_number != clean_number:
-                    vals['connect_number'] = clean_number
-                if provider and channel.connect_channel_provider != provider:
-                    vals['connect_channel_provider'] = provider
-                if vals:
-                    channel.write(vals)
+                    channel.connect_number = clean_number
                 return channel
             if not create_if_not_found:
                 return self.browse()
             members = self._connect_agent_partners() | partner
-            vals = {
+            return self._connect_create_channel({
                 'name': partner.display_name,
                 'channel_type': 'connect_messages',
                 'connect_partner_id': partner.id,
                 'connect_number': clean_number or partner.phone_sanitized,
                 'connect_channel_provider': provider,
-            }
-            if release.version_info[0] < 17:
-                vals['public'] = 'private'
-            vals.update(self._connect_member_create_values(members))
-            return self.sudo().with_context(mail_create_nosubscribe=True).create(vals)
-        if clean_number:
+            }, members)
+        elif clean_number:
+            # Phone-number-only channel: no partner yet, keyed on the clean number.
             channel = self.sudo().search([
                 ('channel_type', '=', 'connect_messages'),
                 ('connect_partner_id', '=', False),
@@ -148,42 +135,42 @@ class DiscussChannel(models.Model):
             if not create_if_not_found:
                 return self.browse()
             members = self._connect_agent_partners()
-            vals = {
+            return self._connect_create_channel({
                 'name': clean_number,
                 'channel_type': 'connect_messages',
                 'connect_partner_id': False,
                 'connect_number': clean_number,
                 'connect_channel_provider': provider,
-            }
-            if release.version_info[0] < 17:
-                vals['public'] = 'private'
-            vals.update(self._connect_member_create_values(members))
-            return self.sudo().with_context(mail_create_nosubscribe=True).create(vals)
+            }, members)
         return self.browse()
 
     def connect_create_partner(self, partner_name=None):
+        """Create a contact for a phone-number-only channel and link it to the channel."""
         self.ensure_one()
         if self.channel_type != 'connect_messages':
             raise ValidationError('Not a Connect Messages channel')
         if self.connect_partner_id:
             raise ValidationError('Channel already has a contact')
-        if not self.connect_number:
+        number = self.connect_number
+        if not number:
             raise ValidationError('Channel has no phone number')
+        # New contacts get Odoo's default mail "smiley" avatar.
         default_image = False
         try:
-            with file_open('mail/static/src/img/smiley/avatar.jpg', 'rb') as stream:
-                default_image = base64.b64encode(stream.read())
+            with file_open('mail/static/src/img/smiley/avatar.jpg', 'rb') as f:
+                default_image = base64.b64encode(f.read())
         except Exception:
             logger.warning('Could not read default contact avatar', exc_info=True)
         partner = self.env['res.partner'].sudo().create({
-            'name': partner_name or self.connect_number,
-            'phone': self.connect_number,
+            'name': partner_name or number,
+            'phone': number,
             'image_1920': default_image or False,
         })
         self._connect_link_partner(partner)
         return {'partner_id': partner.id, 'partner_name': partner.display_name}
 
     def _connect_link_partner(self, partner):
+        """Link a newly-created partner to this phone-number-only channel."""
         self.ensure_one()
         self.sudo().write({
             'connect_partner_id': partner.id,
@@ -192,30 +179,37 @@ class DiscussChannel(models.Model):
         if partner not in self._connect_member_partners():
             if release.version_info[0] >= 17:
                 self.sudo().write({
-                    'channel_member_ids': [
-                        Command.create({'partner_id': partner.id}),
-                    ],
+                    'channel_member_ids': [Command.create({'partner_id': partner.id})]
                 })
             else:
                 self.sudo().write({
-                    'channel_partner_ids': [Command.link(partner.id)],
+                    'channel_partner_ids': [Command.link(partner.id)]
                 })
+        # Back-fill partner on existing connect.message records for this number.
         self.env['connect.message'].sudo().search([
             ('from_number', '=', self.connect_number),
             ('partner', '=', False),
         ]).write({'partner': partner.id})
 
-    def _connect_message_body(self, connect_message):
-        body_text = connect_message.body or ''
-        if connect_message.media_url:
-            return Markup(
-                "<div class='d-flex flex-column'><span>{}</span>{}</div>"
-            ).format(body_text, connect_message.media_widget)
-        return Markup('<span>{}</span>').format(body_text)
-
     def _connect_post_inbound(self, connect_message, parent_id=False):
+        """Mirror an incoming connect.message into this channel as a mail.message.
+
+        ``parent_id`` quotes a parent mail.message (Discuss reply) when the inbound
+        is a reply to an earlier message in this thread (see the customer-reply
+        screenshot in the feature request).
+        """
         self.ensure_one()
         partner = connect_message.partner
+        body_txt = connect_message.body or ''
+        if connect_message.media_url:
+            body = Markup("<div class='d-flex flex-column'>"
+                          "<span>{}</span>{}</div>").format(
+                              body_txt, connect_message.media_widget)
+        else:
+            body = Markup("<span>{}</span>").format(body_txt)
+        # Author the message as the customer's partner when known. For an unknown
+        # number leave author_id empty and surface the phone number via email_from
+        # so it shows as the sender name (instead of OdooBot/partner_root).
         if partner:
             author_vals = {'author_id': partner.id}
         else:
@@ -223,82 +217,96 @@ class DiscussChannel(models.Model):
                 'author_id': False,
                 'email_from': self.connect_number or connect_message.from_number,
             }
-        post_kwargs = {
-            'body': self._connect_message_body(connect_message),
-            'message_type': 'connect_message',
-            'subtype_xmlid': 'mail.mt_comment',
+        post_kwargs = dict(
+            body=body,
+            message_type='connect_message',
+            subtype_xmlid='mail.mt_comment',
             **author_vals,
-        }
+        )
         if parent_id:
             post_kwargs['parent_id'] = parent_id
-        message = self.sudo().with_context(connect_mirror=True).message_post(
-            **post_kwargs)
+        msg = self.sudo().with_context(connect_mirror=True).message_post(**post_kwargs)
         connect_message.write({
             'channel_id': self.id,
-            'channel_message_id': message.id,
+            'channel_message_id': msg.id,
         })
-        message.connect_message = connect_message.id
+        msg.connect_message = connect_message.id
         if connect_message.message_type == 'whatsapp':
-            self.connect_last_inbound_whatsapp_id = message.id
+            self.connect_last_inbound_whatsapp_id = msg.id
+        # Surface in agents' sidebars: re-pin for all members on new inbound.
         self._connect_resurface()
-        return message
+        return msg
 
     def _connect_post_outbound(self, connect_message):
+        """Mirror an outbound connect.message (sent from a record's chatter) into
+        this channel, keeping the Discuss thread in sync. Does not re-send — the
+        connect_mirror context bypasses the outbound send in ``message_post``.
+        """
         self.ensure_one()
-        author = (
-            connect_message.sender_user.partner_id
-            or self.env.user.partner_id
-        )
-        message = self.sudo().with_context(connect_mirror=True).message_post(
-            body=self._connect_message_body(connect_message),
+        body_txt = connect_message.body or ''
+        if connect_message.media_url:
+            body = Markup("<div class='d-flex flex-column'>"
+                          "<span>{}</span>{}</div>").format(
+                              body_txt, connect_message.media_widget)
+        else:
+            body = Markup("<span>{}</span>").format(body_txt)
+        author = connect_message.sender_user.partner_id or self.env.user.partner_id
+        msg = self.sudo().with_context(connect_mirror=True).message_post(
+            body=body,
             message_type='connect_message',
             subtype_xmlid='mail.mt_comment',
             author_id=author.id,
         )
         connect_message.write({
             'channel_id': self.id,
-            'channel_message_id': message.id,
+            'channel_message_id': msg.id,
         })
-        message.connect_message = connect_message.id
+        msg.connect_message = connect_message.id
+        # Surface in agents' sidebars: re-pin for all members on new activity.
         self._connect_resurface()
-        return message
+        return msg
 
     def _connect_resurface(self):
+        """Un-archive the thread for any member who archived (unpinned) it.
+
+        Resets ``unpin_dt`` so the channel re-pins, and pushes the channel to each
+        affected member's Discuss sidebar so an archived conversation reappears in
+        real time when a new message arrives.
+        """
         self.ensure_one()
-        if release.version_info[0] >= 17:
-            archived = self.channel_member_ids.filtered(lambda member: not member.is_pinned)
+        if release.version_info[0] < 17:
+            archived = self.channel_last_seen_partner_ids.filtered(
+                lambda m: not m.is_pinned)
             if not archived:
                 return
-            archived.write({'unpin_dt': False})
+            archived.write({
+                'is_pinned': True,
+                'last_interest_dt': fields.Datetime.now(),
+            })
             for member in archived:
                 user = member.partner_id.user_ids[:1]
                 if user:
-                    Store(bus_channel=user).add(self.with_user(user)).bus_send()
+                    info = self.with_user(user).sudo().channel_info()[0]
+                    self.env['bus.bus'].sudo()._sendone(
+                        member.partner_id,
+                        'mail.channel/legacy_insert',
+                        info,
+                    )
             return
-
-        archived = self.channel_last_seen_partner_ids.filtered(
-            lambda member: not member.is_pinned)
+        archived = self.channel_member_ids.filtered(lambda m: not m.is_pinned)
         if not archived:
             return
-        archived.write({
-            'is_pinned': True,
-            'last_interest_dt': fields.Datetime.now(),
-        })
+        archived.write({'unpin_dt': False})
         for member in archived:
             user = member.partner_id.user_ids[:1]
             if user:
-                info = self.with_user(user).sudo().channel_info()[0]
-                self.env['bus.bus'].sudo()._sendone(
-                    member.partner_id,
-                    'mail.channel/legacy_insert',
-                    info,
-                )
+                Store(bus_channel=user).add(self.with_user(user)).bus_send()
 
     if release.version_info[0] >= 17:
         def _get_allowed_message_params(self):
+            # Allow the composer to pass provider/sender through the post route.
             return super()._get_allowed_message_params() | {
-                'connect_provider', 'connect_sender_id',
-            }
+                'connect_provider', 'connect_sender_id'}
 
     def message_post(self, *args, **kwargs):
         connect_provider = kwargs.pop('connect_provider', None)
@@ -311,98 +319,83 @@ class DiscussChannel(models.Model):
         )
         message = super().message_post(*args, **kwargs)
         if is_outbound and message:
-            self._connect_send_outbound(
-                message, connect_provider, connect_sender_id)
+            try:
+                self._connect_send_outbound(message, connect_provider, connect_sender_id)
+            except Exception:
+                logger.exception('Connect outbound send failed for channel %s', self.id)
+                raise
         return message
 
     def _connect_recipient(self):
         self.ensure_one()
-        return self.connect_number or self.connect_partner_id.phone_sanitized
+        if self.connect_number:
+            return self.connect_number
+        return self.connect_partner_id.phone_sanitized
 
     def _connect_send_outbound(self, message, provider, sender_id):
         self.ensure_one()
         partner = self.connect_partner_id
         recipient = self._connect_recipient()
-        if not recipient:
-            raise ValidationError('Channel has no recipient phone number')
         body = html2plaintext(message.body) if message.body else ''
         provider = provider or self.connect_channel_provider or 'sms'
         res_id = partner.id or None
         res_model = 'res.partner' if res_id else None
-        last_inbound = self.env['connect.message'].sudo().search([
-            ('channel_id', '=', self.id),
-            ('status', '=', 'received'),
-        ], order='create_date desc', limit=1)
+
+        # Find the last inbound message so we know which of our Twilio numbers
+        # the customer originally messaged — reply from that same line.
+        last_inbound = self.env['connect.message'].sudo().search(
+            [('channel_id', '=', self.id), ('status', '=', 'received')],
+            order='create_date desc', limit=1)
+
         if provider == 'whatsapp':
-            sender_model = self.env['connect.whatsapp_sender']
+            Sender = self.env['connect.whatsapp_sender']
             if sender_id:
-                whatsapp_sender = sender_model.sudo().browse(int(sender_id))
+                wa_sender = Sender.sudo().browse(int(sender_id))
             elif last_inbound:
-                whatsapp_sender = sender_model.sudo().search([
-                    ('number', '=', last_inbound.to_number),
-                ], limit=1)
-                if not whatsapp_sender:
-                    whatsapp_sender = sender_model.get_default_sender(self.env.user)
+                to_num = last_inbound.to_number or ''
+                wa_sender = Sender.sudo().search([('number', '=', to_num)], limit=1)
+                if not wa_sender:
+                    wa_sender = Sender.get_default_sender(self.env.user)
             else:
-                whatsapp_sender = sender_model.get_default_sender(self.env.user)
-            if not whatsapp_sender:
-                raise ValidationError('No WhatsApp sender is configured')
-            connect_message = whatsapp_sender.send_whatsapp(
-                recipient=recipient,
-                body=body,
-                res_model=res_model,
-                res_id=res_id,
-                raise_on_error=True,
-                skip_chatter=True,
-            )
+                wa_sender = Sender.get_default_sender(self.env.user)
+            cmsg = wa_sender.send_whatsapp(
+                recipient=recipient, body=body,
+                res_model=res_model, res_id=res_id,
+                raise_on_error=True, skip_chatter=True)
         else:
-            caller_id = sender_id or None
-            if not caller_id and last_inbound:
-                caller_id = last_inbound.to_number or None
-            connect_message = self.env['connect.message'].send(
-                recipient,
-                body,
-                res_id=res_id,
-                res_model=res_model,
-                outgoing_callerid=caller_id,
-                media_urls=self._connect_media_urls(message),
-                skip_chatter=True,
-            )
-        if connect_message:
-            connect_message.sudo().write({
-                'channel_message_id': message.id,
-                'channel_id': self.id,
-            })
-            message.sudo().connect_message = connect_message.id
-        return connect_message
+            media_urls = self._connect_media_urls(message)
+            callerid = sender_id or None
+            if not callerid and last_inbound:
+                callerid = last_inbound.to_number or None
+            cmsg = self.env['connect.message'].send(
+                recipient, body, res_id=res_id, res_model=res_model,
+                outgoing_callerid=callerid, media_urls=media_urls,
+                skip_chatter=True)
+        if cmsg:
+            cmsg.sudo().write({'channel_message_id': message.id, 'channel_id': self.id})
+            message.sudo().connect_message = cmsg.id
+        return cmsg
 
     def _connect_media_urls(self, message):
         urls = []
-        base_url = (
-            self.env['connect.settings'].sudo().get_param('api_url')
-            or self.get_base_url()
-        )
-        for attachment in message.attachment_ids:
-            token = attachment.sudo().generate_access_token()[0]
+        base = self.env['connect.settings'].sudo().get_param('api_url') or self.get_base_url()
+        for att in message.attachment_ids:
+            token = att.sudo().generate_access_token()[0]
             urls.append('%s/web/content/%d?access_token=%s&download=true' % (
-                base_url.rstrip('/'), attachment.id, token,
-            ))
+                base.rstrip('/'), att.id, token))
         return urls
 
     if release.version_info[0] >= 17:
         def _to_store(self, store, *args, **kwargs):
             super()._to_store(store, *args, **kwargs)
-            for channel in self.filtered(
-                    lambda rec: rec.channel_type == 'connect_messages'):
+            for channel in self.filtered(lambda c: c.channel_type == 'connect_messages'):
+                # add_records_fields (not add) avoids re-entering _to_store recursively.
                 store.add_records_fields(channel, {
-                    'connect_whatsapp_window_open': (
-                        channel.connect_whatsapp_window_open),
-                    'connect_whatsapp_valid_until': (
-                        channel.connect_whatsapp_valid_until),
+                    'connect_whatsapp_window_open': channel.connect_whatsapp_window_open,
+                    'connect_whatsapp_valid_until': channel.connect_whatsapp_valid_until,
                     'connect_partner_id': channel.connect_partner_id.id or False,
                     'connect_number': channel.connect_number,
-                    'connect_channel_provider': (
-                        channel.connect_channel_provider or 'sms'),
+                    'connect_channel_provider': channel.connect_channel_provider or 'sms',
                 })
     else:
         def channel_info(self):
@@ -412,16 +405,15 @@ class DiscussChannel(models.Model):
                 channel = channels.get(info['id'])
                 if channel and channel.channel_type == 'connect_messages':
                     info.update({
-                        'connect_whatsapp_window_open': (
-                            channel.connect_whatsapp_window_open),
+                        'connect_whatsapp_window_open':
+                            channel.connect_whatsapp_window_open,
                         'connect_whatsapp_valid_until': (
                             fields.Datetime.to_string(
                                 channel.connect_whatsapp_valid_until)
                             if channel.connect_whatsapp_valid_until else False),
-                        'connect_partner_id': (
-                            channel.connect_partner_id.id or False),
+                        'connect_partner_id': channel.connect_partner_id.id or False,
                         'connect_number': channel.connect_number,
-                        'connect_channel_provider': (
-                            channel.connect_channel_provider or 'sms'),
+                        'connect_channel_provider':
+                            channel.connect_channel_provider or 'sms',
                     })
             return info_list

--- a/connect/models/discuss_channel_member.py
+++ b/connect/models/discuss_channel_member.py
@@ -13,33 +13,30 @@ class DiscussChannelMember(models.Model):
 
     @api.autovacuum
     def _gc_unpin_connect_channels(self):
-        """Unpin read customer threads idle for more than one day."""
+        """Unpin read connect_messages channels idle >1 day to keep sidebars clean."""
         one_day_ago = fields.Datetime.now() - timedelta(days=1)
-        if release.version_info[0] >= 17:
+        if release.version_info[0] < 17:
             members = self.search([
                 ('is_pinned', '=', True),
                 ('channel_id.channel_type', '=', 'connect_messages'),
-                ('last_seen_dt', '<', one_day_ago),
+                ('last_interest_dt', '<', one_day_ago),
             ], limit=1000)
             to_unpin = members.filtered(
-                lambda member: member.message_unread_counter == 0)
-            to_unpin.unpin_dt = fields.Datetime.now()
+                lambda m: m.channel_id.message_unread_counter == 0)
+            to_unpin.write({'is_pinned': False})
             for member in to_unpin:
-                member._bus_send(
-                    'discuss.channel/unpin', {'id': member.channel_id.id})
+                self.env['bus.bus'].sudo()._sendone(
+                    member.partner_id,
+                    'mail.channel/unpin',
+                    {'id': member.channel_id.id},
+                )
             return
-
         members = self.search([
             ('is_pinned', '=', True),
             ('channel_id.channel_type', '=', 'connect_messages'),
-            ('last_interest_dt', '<', one_day_ago),
+            ('last_seen_dt', '<', one_day_ago),
         ], limit=1000)
-        to_unpin = members.filtered(
-            lambda member: member.channel_id.message_unread_counter == 0)
-        to_unpin.write({'is_pinned': False})
+        to_unpin = members.filtered(lambda m: m.message_unread_counter == 0)
+        to_unpin.unpin_dt = fields.Datetime.now()
         for member in to_unpin:
-            self.env['bus.bus'].sudo()._sendone(
-                member.partner_id,
-                'mail.channel/unpin',
-                {'id': member.channel_id.id},
-            )
+            member._bus_send("discuss.channel/unpin", {"id": member.channel_id.id})

--- a/connect/models/discuss_channel_member.py
+++ b/connect/models/discuss_channel_member.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from datetime import timedelta
+
+from odoo import api, fields, models, release
+
+
+class DiscussChannelMember(models.Model):
+    _inherit = (
+        'discuss.channel.member'
+        if release.version_info[0] >= 17
+        else 'mail.channel.partner'
+    )
+
+    @api.autovacuum
+    def _gc_unpin_connect_channels(self):
+        """Unpin read customer threads idle for more than one day."""
+        one_day_ago = fields.Datetime.now() - timedelta(days=1)
+        if release.version_info[0] >= 17:
+            members = self.search([
+                ('is_pinned', '=', True),
+                ('channel_id.channel_type', '=', 'connect_messages'),
+                ('last_seen_dt', '<', one_day_ago),
+            ], limit=1000)
+            to_unpin = members.filtered(
+                lambda member: member.message_unread_counter == 0)
+            to_unpin.unpin_dt = fields.Datetime.now()
+            for member in to_unpin:
+                member._bus_send(
+                    'discuss.channel/unpin', {'id': member.channel_id.id})
+            return
+
+        members = self.search([
+            ('is_pinned', '=', True),
+            ('channel_id.channel_type', '=', 'connect_messages'),
+            ('last_interest_dt', '<', one_day_ago),
+        ], limit=1000)
+        to_unpin = members.filtered(
+            lambda member: member.channel_id.message_unread_counter == 0)
+        to_unpin.write({'is_pinned': False})
+        for member in to_unpin:
+            self.env['bus.bus'].sudo()._sendone(
+                member.partner_id,
+                'mail.channel/unpin',
+                {'id': member.channel_id.id},
+            )

--- a/connect/models/mail.py
+++ b/connect/models/mail.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import api, fields, models, release
 
 
 class MailMessage(models.Model):
@@ -6,8 +6,14 @@ class MailMessage(models.Model):
 
     connect_message = fields.Many2one('connect.message')
     message_type = fields.Selection(
-        selection_add=[('WhatsApp', 'WhatsApp')],
-        ondelete={'WhatsApp': lambda recs: recs.write({'message_type': 'comment'})},
+        selection_add=[
+            ('WhatsApp', 'WhatsApp'),
+            ('connect_message', 'Connect Message'),
+        ],
+        ondelete={
+            'WhatsApp': lambda recs: recs.write({'message_type': 'comment'}),
+            'connect_message': lambda recs: recs.write({'message_type': 'comment'}),
+        },
     )
 
     @api.model
@@ -19,6 +25,35 @@ class MailMessage(models.Model):
             return {'from_number': message.from_number, 'to_number': message.to_number}
         else:
             return False
+
+    if release.version_info[0] >= 17:
+        def _to_store(self, store, *args, **kwargs):
+            super()._to_store(store, *args, **kwargs)
+            linked = self.filtered(
+                lambda message: (
+                    message.message_type == 'connect_message'
+                    and message.connect_message
+                )
+            )
+            for message in linked:
+                connect_message = message.sudo().connect_message
+                store.add_records_fields(message, {
+                    'connectStatus': connect_message.status,
+                    'connectMessageType': connect_message.message_type,
+                })
+    else:
+        def message_format(self, format_reply=True):
+            values = super().message_format(format_reply=format_reply)
+            by_id = {message.id: message.sudo() for message in self}
+            for value in values:
+                message = by_id.get(value['id'])
+                if (message and message.message_type == 'connect_message'
+                        and message.connect_message):
+                    value.update({
+                        'connectStatus': message.connect_message.status,
+                        'connectMessageType': message.connect_message.message_type,
+                    })
+            return values
 
 
 class MailNotification(models.Model):

--- a/connect/models/mail.py
+++ b/connect/models/mail.py
@@ -30,16 +30,13 @@ class MailMessage(models.Model):
         def _to_store(self, store, *args, **kwargs):
             super()._to_store(store, *args, **kwargs)
             linked = self.filtered(
-                lambda message: (
-                    message.message_type == 'connect_message'
-                    and message.connect_message
-                )
-            )
+                lambda m: m.message_type == 'connect_message' and m.connect_message)
             for message in linked:
-                connect_message = message.sudo().connect_message
+                cmsg = message.sudo().connect_message
+                # add_records_fields (not add) avoids re-entering _to_store recursively.
                 store.add_records_fields(message, {
-                    'connectStatus': connect_message.status,
-                    'connectMessageType': connect_message.message_type,
+                    'connectStatus': cmsg.status,
+                    'connectMessageType': cmsg.message_type,
                 })
     else:
         def message_format(self, format_reply=True):

--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -456,14 +456,16 @@ class ConnectMessage(models.Model):
         # Display-only WhatsApp marker so the note shows the WhatsApp logo
         # (is_read + 'ready' => icon only: no email, no delivery-failure envelope).
         if message._provider() == 'whatsapp':
-            self.env['mail.notification'].sudo().create([{
-                'author_id': chatter.author_id.id,
+            notification_values = {
                 'mail_message_id': chatter.id,
                 'res_partner_id': chatter.author_id.id,
                 'notification_type': 'WhatsApp',
                 'is_read': True,
                 'notification_status': 'ready',
-            }])
+            }
+            if release.version_info[0] >= 17:
+                notification_values['author_id'] = chatter.author_id.id
+            self.env['mail.notification'].sudo().create(notification_values)
         return chatter
 
     def send(self, recipient, body, res_id=None, res_model=None, outgoing_callerid=None, media_urls=None, skip_chatter=False):
@@ -517,7 +519,6 @@ class ConnectMessage(models.Model):
                 kwargs.update({'author_id': sender_user.partner_id.id})
                 chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
                 mail_notification_values = [{
-                    'author_id': chatter.author_id.id,
                     'mail_message_id': chatter.id,
                     'res_partner_id': chatter.author_id.id,
                     'sms_number': sender,
@@ -525,6 +526,8 @@ class ConnectMessage(models.Model):
                     'is_read': True,
                     'notification_status': 'ready',
                 }]
+                if release.version_info[0] >= 17:
+                    mail_notification_values[0]['author_id'] = chatter.author_id.id
                 self.env['mail.notification'].sudo().create(mail_notification_values)
         # Mirror an outbound sent from a record's chatter into the existing Discuss
         # thread (only when one already exists). The Discuss-composer path passes
@@ -655,14 +658,16 @@ class ConnectMessage(models.Model):
                     message_type='sms',
                     author_id=author,
                 )
-                self.env['mail.notification'].sudo().create([{
-                    'author_id': chatter.author_id.id,
+                notification_values = {
                     'mail_message_id': chatter.id,
                     'res_partner_id': chatter.author_id.id,
                     #'sms_number': self.number, # NO number field.
                     'notification_type': 'sms',
                     'is_read': True,
                     'notification_status': 'ready',
-                }])
+                }
+                if release.version_info[0] >= 17:
+                    notification_values['author_id'] = chatter.author_id.id
+                self.env['mail.notification'].sudo().create(notification_values)
         except Exception as e:
             logger.warning('Failed to post SMS chatter message on %s,%s: %s', res_model, res_id, e)

--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -76,13 +76,21 @@ class ConnectMessage(models.Model):
     media_url = fields.Char()
     media_content_type = fields.Char()
     transcription_error = fields.Char()
+    # ODU-37: link to the mirrored Discuss message/channel.
+    # mail_message_id is the copy posted to a record's *chatter* (log note);
+    # channel_message_id is the mirror posted into the *Discuss* channel.
     mail_message_id = fields.Many2one(
-        'mail.message', index=True, string='Chatter Message', ondelete='set null')
+        'mail.message',
+        index='btree_not_null' if release.version_info[0] >= 17 else True,
+                                      string='Chatter Message', ondelete='set null')
     channel_message_id = fields.Many2one(
-        'mail.message', index=True, string='Discuss Message', ondelete='set null')
+        'mail.message',
+        index='btree_not_null' if release.version_info[0] >= 17 else True,
+                                         string='Discuss Message', ondelete='set null')
     channel_id = fields.Many2one(
         'discuss.channel' if release.version_info[0] >= 17 else 'mail.channel',
-        index=True, string='Discuss Channel', ondelete='set null')
+        index='btree_not_null' if release.version_info[0] >= 17 else True,
+                                 string='Discuss Channel', ondelete='set null')
     if release.version_info[0] >= 17.0:
         media_widget = fields.Html(compute='_get_media_widget', string='Media', sanitize=False)
     else:
@@ -199,16 +207,19 @@ class ConnectMessage(models.Model):
 
     @staticmethod
     def _strip_provider_scheme(number):
-        """Return an E.164 number without Twilio's ``whatsapp:`` scheme."""
+        """Return the bare E.164 number without the 'whatsapp:' Twilio scheme."""
         number = number or ''
         return number[len('whatsapp:'):] if number.startswith('whatsapp:') else number
 
     def _provider(self):
+        """Messaging provider for this message: 'whatsapp' or 'sms' (mms is sms)."""
         self.ensure_one()
         return 'whatsapp' if self.message_type == 'whatsapp' else 'sms'
 
     def _mail_message_type(self):
-        """Map Connect's normalized provider to mail's selection value."""
+        """Tag value for mail.message.message_type / mail.notification.notification_type,
+        whose selections use the capitalized 'WhatsApp' (see connect/models/mail.py).
+        sms/mms are passed through unchanged."""
         self.ensure_one()
         return 'WhatsApp' if self.message_type == 'whatsapp' else self.message_type
 
@@ -244,6 +255,7 @@ class ConnectMessage(models.Model):
     def get_receive_message_values(self, params):
         from_raw = params.get('From', '') or ''
         num_media = int(params.get('NumMedia', 0))
+        # Detect the provider from the scheme before stripping it for storage.
         if from_raw.startswith('whatsapp:'):
             message_type = 'whatsapp'
         elif num_media > 0:
@@ -350,6 +362,8 @@ class ConnectMessage(models.Model):
                             defaults = dict(ast.literal_eval(config.default_values or '{}'))
                         except Exception as e:
                             logger.error('Invalid default data: %s\n%s', config.default_values, e)
+                    # For res.partner destination: skip auto-creation; the agent will
+                    # create the contact manually from the Discuss channel if needed.
                     if dest_model != 'res.partner' and dest_model in self.env:
                         try:
                             new_rec = self.env[dest_model].with_context(mail_create_nosubscribe=True).sudo().create_record_from_message(message, default_values=defaults)
@@ -361,29 +375,34 @@ class ConnectMessage(models.Model):
                             logger.warning('create_record_from_message failed for %s: %s', dest_model, e)
                     elif dest_model not in self.env:
                         logger.warning('Destination model %s not found', dest_model)
+                # Mirror the inbound onto chatters: the resolved target record
+                # (when valid) and — for a known partner — always the partner's
+                # own record (deduped). A brand-new unknown number gets no chatter;
+                # it lives only in the Discuss channel.
                 chatter_targets = []
                 if valid_target and target_msg and target_msg.res_model and target_msg.res_id:
-                    target_rec = self.env[target_msg.res_model].with_user(
-                        SUPERUSER_ID).browse(target_msg.res_id)
+                    target_rec = self.env[target_msg.res_model].with_user(SUPERUSER_ID).browse(target_msg.res_id)
                     if target_rec.exists() and hasattr(target_rec, 'message_post'):
                         chatter_targets.append(target_rec)
                 if partner and not any(
-                        rec._name == 'res.partner' and rec.id == partner.id
-                        for rec in chatter_targets):
+                        r._name == 'res.partner' and r.id == partner.id for r in chatter_targets):
                     chatter_targets.append(partner.with_user(SUPERUSER_ID))
                 primary_chatter = False
                 for obj in chatter_targets:
-                    chatter = self._post_inbound_chatter_note(
-                        obj, message, values.get('body'), partner)
+                    chatter = self._post_inbound_chatter_note(obj, message, values.get('body'), partner)
                     if not chatter:
                         continue
+                    # Prefer the partner's own record as the canonical chatter copy.
                     if obj._name == 'res.partner' and partner and obj.id == partner.id:
                         primary_chatter = chatter
                     elif not primary_chatter:
                         primary_chatter = chatter
                 if primary_chatter:
                     message.mail_message_id = primary_chatter.id
-
+                # Mirror inbound into Discuss: use partner channel when known,
+                # otherwise a phone-number-only channel so the agent can see it.
+                # When the inbound is a reply (WhatsApp OriginalRepliedMessageSid),
+                # quote the parent's Discuss mirror so the thread shows the reply.
                 try:
                     channel = self.env[self._connect_channel_model()]._get_connect_channel(
                         partner, number=from_number, provider=message._provider(),
@@ -406,20 +425,25 @@ class ConnectMessage(models.Model):
                         'error_message': params.get('ErrorMessage'),
                         'has_error': True,
                     })
-                message._bus_send_connect_status()
         except Exception as e:
             logger.error(f"Error handling incoming SMS: {e}")
         return str(MessagingResponse())  # Return empty TwiML response, i.e. no reply.
 
     def _post_inbound_chatter_note(self, obj, message, body_text, partner):
+        """Post an inbound connect.message as a quiet log note on obj's chatter.
+
+        Returns the created mail.message (or False). Kept as a log note (mt_note)
+        so followers are not emailed — agents see it in the Discuss channel anyway;
+        a comment would yield a red delivery-failure envelope when no SMTP is set.
+        """
         if not (obj and obj.exists() and hasattr(obj, 'message_post')):
             return False
         body = Markup("<div class='d-flex flex-row px-1'>"
                       "<span class='px-1'>{}</span></div>").format(body_text or '')
         if message.media_url:
             body = Markup("<div class='d-flex flex-row'>"
-                          "<span class='px-1'>{}</span><br/>{}</div>").format(
-                              body_text or '', message.media_widget)
+                          "<span class='px-1'>{}</span>"
+                          "<br/>{}</div>").format(body_text or '', message.media_widget)
         kwargs = {
             'body': body,
             'subtype_id': self.env.ref('mail.mt_note').id,
@@ -429,20 +453,20 @@ class ConnectMessage(models.Model):
             kwargs['author_id'] = partner.id
         chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
         chatter.connect_message = message
+        # Display-only WhatsApp marker so the note shows the WhatsApp logo
+        # (is_read + 'ready' => icon only: no email, no delivery-failure envelope).
         if message._provider() == 'whatsapp':
-            notification_vals = {
+            self.env['mail.notification'].sudo().create([{
                 'author_id': chatter.author_id.id,
                 'mail_message_id': chatter.id,
                 'res_partner_id': chatter.author_id.id,
                 'notification_type': 'WhatsApp',
                 'is_read': True,
                 'notification_status': 'ready',
-            }
-            self.env['mail.notification'].sudo().create(notification_vals)
+            }])
         return chatter
 
-    def send(self, recipient, body, res_id=None, res_model=None,
-             outgoing_callerid=None, media_urls=None, skip_chatter=False):
+    def send(self, recipient, body, res_id=None, res_model=None, outgoing_callerid=None, media_urls=None, skip_chatter=False):
         self.env['oduist.license'].check_license('connect', silent=False)
         sender_user = self.env.user
         message_data = {
@@ -488,7 +512,7 @@ class ConnectMessage(models.Model):
                 kwargs = {
                     'body': chat_body,
                     'subtype_id': mt_note,
-                    'message_type': message._mail_message_type()
+                    'message_type': message._mail_message_type(),
                 }
                 kwargs.update({'author_id': sender_user.partner_id.id})
                 chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
@@ -502,7 +526,9 @@ class ConnectMessage(models.Model):
                     'notification_status': 'ready',
                 }]
                 self.env['mail.notification'].sudo().create(mail_notification_values)
-
+        # Mirror an outbound sent from a record's chatter into the existing Discuss
+        # thread (only when one already exists). The Discuss-composer path passes
+        # skip_chatter=True and already posts into the channel itself.
         if not skip_chatter:
             try:
                 channel = self.env[self._connect_channel_model()]._get_connect_channel(
@@ -521,15 +547,15 @@ class ConnectMessage(models.Model):
             # Messaging is only supported in the US region.
             client = self.env['connect.settings'].get_client(region=False)
             # Send message to twilio
-            message_kwargs = dict(
-                to=recipient,
-                from_=sender,
-                body=body,
-                status_callback=status_callback_url,
-            )
+            create_kwargs = {
+                'to': recipient,
+                'from_': sender,
+                'body': body,
+                'status_callback': status_callback_url,
+            }
             if media_urls:
-                message_kwargs['media_url'] = media_urls
-            message = client.messages.create(**message_kwargs)
+                create_kwargs['media_url'] = media_urls
+            message = client.messages.create(**create_kwargs)
             if message.error_code:
                 return False
             logger.info('Message to %s is sent.', recipient)
@@ -595,13 +621,14 @@ class ConnectMessage(models.Model):
                 self.chatter_post(message.res_model, message.res_id, connect_partner.id, chatter_message)
             if vals:
                 message.write(vals)
+            # ODU-37: push status onto the Discuss bubble if mirrored.
             message._bus_send_connect_status()
         except Exception as e:
             logger.warning('Failed to update message status for %s: %s', sid, e)
         return True
 
     def _bus_send_connect_status(self):
-        for message in self.filtered(lambda rec: rec.channel_message_id and rec.channel_id):
+        for message in self.filtered(lambda m: m.channel_message_id and m.channel_id):
             if release.version_info[0] >= 17:
                 Store(bus_channel=message.channel_id).add(
                     message.channel_message_id,
@@ -611,8 +638,10 @@ class ConnectMessage(models.Model):
                 self.env['bus.bus'].sudo()._sendone(
                     message.channel_id,
                     'mail.message/insert',
-                    {'id': message.channel_message_id.id,
-                     'connectStatus': message.status},
+                    {
+                        'id': message.channel_message_id.id,
+                        'connectStatus': message.status,
+                    },
                 )
 
     def chatter_post(self, res_model, res_id, author, body):

--- a/connect/models/message.py
+++ b/connect/models/message.py
@@ -22,6 +22,8 @@ from phonenumbers import parse, format_number, PhoneNumberFormat
 from twilio.twiml.messaging_response import MessagingResponse
 
 from odoo import models, fields, api, release
+if release.version_info[0] >= 17:
+    from odoo.addons.mail.tools.discuss import Store
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError
 from odoo.tools import mail
@@ -74,6 +76,13 @@ class ConnectMessage(models.Model):
     media_url = fields.Char()
     media_content_type = fields.Char()
     transcription_error = fields.Char()
+    mail_message_id = fields.Many2one(
+        'mail.message', index=True, string='Chatter Message', ondelete='set null')
+    channel_message_id = fields.Many2one(
+        'mail.message', index=True, string='Discuss Message', ondelete='set null')
+    channel_id = fields.Many2one(
+        'discuss.channel' if release.version_info[0] >= 17 else 'mail.channel',
+        index=True, string='Discuss Channel', ondelete='set null')
     if release.version_info[0] >= 17.0:
         media_widget = fields.Html(compute='_get_media_widget', string='Media', sanitize=False)
     else:
@@ -188,6 +197,25 @@ class ConnectMessage(models.Model):
             else:
                 record.name = f"New {record.message_type}"
 
+    @staticmethod
+    def _strip_provider_scheme(number):
+        """Return an E.164 number without Twilio's ``whatsapp:`` scheme."""
+        number = number or ''
+        return number[len('whatsapp:'):] if number.startswith('whatsapp:') else number
+
+    def _provider(self):
+        self.ensure_one()
+        return 'whatsapp' if self.message_type == 'whatsapp' else 'sms'
+
+    def _mail_message_type(self):
+        """Map Connect's normalized provider to mail's selection value."""
+        self.ensure_one()
+        return 'WhatsApp' if self.message_type == 'whatsapp' else self.message_type
+
+    @api.model
+    def _connect_channel_model(self):
+        return 'discuss.channel' if release.version_info[0] >= 17 else 'mail.channel'
+
     def transcribe_voice_message(self, openai_api_key, media_url):
         result = {}
         try:
@@ -214,12 +242,21 @@ class ConnectMessage(models.Model):
             return result
 
     def get_receive_message_values(self, params):
+        from_raw = params.get('From', '') or ''
+        num_media = int(params.get('NumMedia', 0))
+        if from_raw.startswith('whatsapp:'):
+            message_type = 'whatsapp'
+        elif num_media > 0:
+            message_type = 'mms'
+        else:
+            message_type = 'sms'
         values = {
             'message_sid': params.get('MessageSid'),
-            'from_number': params.get('From'),
-            'to_number': params.get('To'),
+            'from_number': self._strip_provider_scheme(from_raw),
+            'to_number': self._strip_provider_scheme(params.get('To')),
             'body': params.get('Body'),
-            'num_media': int(params.get('NumMedia', 0)),
+            'num_media': num_media,
+            'message_type': message_type,
             'from_city': params.get('FromCity'),
             'from_state': params.get('FromState'),
             'from_zip': params.get('FromZip'),
@@ -250,9 +287,9 @@ class ConnectMessage(models.Model):
                 return
             if params.get('SmsStatus') == 'received':
                 # Create SMS message record
-                from_number = params.get('From')
-                to_number = params.get('To')
                 values = self.get_receive_message_values(params)
+                from_number = values['from_number']
+                to_number = values['to_number']
                 # Media handling (image, audio, video)
                 try:
                     if int(params.get('NumMedia', '0') or 0) > 0:
@@ -313,7 +350,7 @@ class ConnectMessage(models.Model):
                             defaults = dict(ast.literal_eval(config.default_values or '{}'))
                         except Exception as e:
                             logger.error('Invalid default data: %s\n%s', config.default_values, e)
-                    if dest_model in self.env:
+                    if dest_model != 'res.partner' and dest_model in self.env:
                         try:
                             new_rec = self.env[dest_model].with_context(mail_create_nosubscribe=True).sudo().create_record_from_message(message, default_values=defaults)
                             target_msg.write({
@@ -322,32 +359,42 @@ class ConnectMessage(models.Model):
                             })
                         except Exception as e:
                             logger.warning('create_record_from_message failed for %s: %s', dest_model, e)
-                    else:
+                    elif dest_model not in self.env:
                         logger.warning('Destination model %s not found', dest_model)
-                # Add message to chatter at the target record when available and valid
+                chatter_targets = []
                 if valid_target and target_msg and target_msg.res_model and target_msg.res_id:
-                    obj = self.env[target_msg.res_model].with_user(SUPERUSER_ID).browse(target_msg.res_id)
-                    # Double-check existence to be safe in concurrent delete scenarios
-                    if obj.exists() and hasattr(obj, 'message_post'):
-                        body = Markup(f"<div class='d-flex flex-row px-1'>"
-                                f"<span class='px-1'>{values.get('body')}</span></div>")
-                        if message.media_url:
-                            body = Markup(f"<div class='d-flex flex-row'>"
-                                          f"<span class='px-1'>{values.get('body')}</span>"
-                                          f"<br/>{message.media_widget}</div>")
+                    target_rec = self.env[target_msg.res_model].with_user(
+                        SUPERUSER_ID).browse(target_msg.res_id)
+                    if target_rec.exists() and hasattr(target_rec, 'message_post'):
+                        chatter_targets.append(target_rec)
+                if partner and not any(
+                        rec._name == 'res.partner' and rec.id == partner.id
+                        for rec in chatter_targets):
+                    chatter_targets.append(partner.with_user(SUPERUSER_ID))
+                primary_chatter = False
+                for obj in chatter_targets:
+                    chatter = self._post_inbound_chatter_note(
+                        obj, message, values.get('body'), partner)
+                    if not chatter:
+                        continue
+                    if obj._name == 'res.partner' and partner and obj.id == partner.id:
+                        primary_chatter = chatter
+                    elif not primary_chatter:
+                        primary_chatter = chatter
+                if primary_chatter:
+                    message.mail_message_id = primary_chatter.id
 
-                        # Post as a comment to notify subscribed followers similar to incoming mail
-                        mt_comment = self.env.ref('mail.mt_comment').id
-                        kwargs = {
-                            'body': body,
-                            'subtype_id': mt_comment,
-                            'message_type': message.message_type
-                        }
-                        if partner:
-                            kwargs.update({'author_id': partner.id})
-                        chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
-                        chatter.connect_message = message
-                        # Let Odoo generate notifications for followers automatically (no manual mail.notification)
+                try:
+                    channel = self.env[self._connect_channel_model()]._get_connect_channel(
+                        partner, number=from_number, provider=message._provider(),
+                        create_if_not_found=True)
+                    parent_id = False
+                    if (parent_msg and parent_msg.channel_message_id
+                            and parent_msg.channel_id.id == channel.id):
+                        parent_id = parent_msg.channel_message_id.id
+                    channel._connect_post_inbound(message, parent_id=parent_id)
+                except Exception as e:
+                    logger.warning('Connect Discuss mirror failed: %s', e)
             else:
                 # Update message status
                 logger.info("Received Update Twilio SMS webhook data:\n%s", params)
@@ -359,15 +406,47 @@ class ConnectMessage(models.Model):
                         'error_message': params.get('ErrorMessage'),
                         'has_error': True,
                     })
+                message._bus_send_connect_status()
         except Exception as e:
             logger.error(f"Error handling incoming SMS: {e}")
         return str(MessagingResponse())  # Return empty TwiML response, i.e. no reply.
 
-    def send(self, recipient, body, res_id=None, res_model=None, outgoing_callerid=None):
+    def _post_inbound_chatter_note(self, obj, message, body_text, partner):
+        if not (obj and obj.exists() and hasattr(obj, 'message_post')):
+            return False
+        body = Markup("<div class='d-flex flex-row px-1'>"
+                      "<span class='px-1'>{}</span></div>").format(body_text or '')
+        if message.media_url:
+            body = Markup("<div class='d-flex flex-row'>"
+                          "<span class='px-1'>{}</span><br/>{}</div>").format(
+                              body_text or '', message.media_widget)
+        kwargs = {
+            'body': body,
+            'subtype_id': self.env.ref('mail.mt_note').id,
+            'message_type': message._mail_message_type(),
+        }
+        if partner:
+            kwargs['author_id'] = partner.id
+        chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
+        chatter.connect_message = message
+        if message._provider() == 'whatsapp':
+            notification_vals = {
+                'author_id': chatter.author_id.id,
+                'mail_message_id': chatter.id,
+                'res_partner_id': chatter.author_id.id,
+                'notification_type': 'WhatsApp',
+                'is_read': True,
+                'notification_status': 'ready',
+            }
+            self.env['mail.notification'].sudo().create(notification_vals)
+        return chatter
+
+    def send(self, recipient, body, res_id=None, res_model=None,
+             outgoing_callerid=None, media_urls=None, skip_chatter=False):
         self.env['oduist.license'].check_license('connect', silent=False)
         sender_user = self.env.user
         message_data = {
-            'message_type': 'sms',
+            'message_type': 'mms' if media_urls else 'sms',
             'to_number': recipient,
             'body': body,
             'sender_user': sender_user.id,
@@ -383,7 +462,7 @@ class ConnectMessage(models.Model):
             if not number:
                 raise ValidationError('You dont have an outgoing callerid number!')
             sender = number.number
-        message = self.client_send(recipient, sender, body)
+        message = self.client_send(recipient, sender, body, media_urls=media_urls)
         if not message:
             raise ValidationError('Unexpected error! Contact admin or maintainer!')
         # Create message record
@@ -401,7 +480,7 @@ class ConnectMessage(models.Model):
         message = self.env['connect.message'].sudo().create(message_data)
 
         # Add message to chatter
-        if res_model and res_id:
+        if res_model and res_id and not skip_chatter:
             mt_note = self.env.ref('mail.mt_note').id
             obj = self.env[res_model].with_user(SUPERUSER_ID).browse(res_id)
             if hasattr(obj, 'message_post'):
@@ -409,7 +488,7 @@ class ConnectMessage(models.Model):
                 kwargs = {
                     'body': chat_body,
                     'subtype_id': mt_note,
-                    'message_type': message.message_type
+                    'message_type': message._mail_message_type()
                 }
                 kwargs.update({'author_id': sender_user.partner_id.id})
                 chatter = obj.with_context(mail_create_nosubscribe=True).message_post(**kwargs)
@@ -418,25 +497,39 @@ class ConnectMessage(models.Model):
                     'mail_message_id': chatter.id,
                     'res_partner_id': chatter.author_id.id,
                     'sms_number': sender,
-                    'notification_type': message.message_type,
+                    'notification_type': message._mail_message_type(),
                     'is_read': True,
                     'notification_status': 'ready',
                 }]
                 self.env['mail.notification'].sudo().create(mail_notification_values)
 
-    def client_send(self, recipient, sender, body):
+        if not skip_chatter:
+            try:
+                channel = self.env[self._connect_channel_model()]._get_connect_channel(
+                    partner, number=recipient, provider=message._provider(),
+                    create_if_not_found=False)
+                if channel:
+                    channel._connect_post_outbound(message)
+            except Exception as e:
+                logger.warning('Connect Discuss outbound mirror failed: %s', e)
+        return message
+
+    def client_send(self, recipient, sender, body, media_urls=None):
         api_url = self.env['connect.settings'].get_param('api_url')
         status_callback_url = urljoin(api_url, 'twilio/webhook/message_status')
         try:
             # Messaging is only supported in the US region.
             client = self.env['connect.settings'].get_client(region=False)
             # Send message to twilio
-            message = client.messages.create(
+            message_kwargs = dict(
                 to=recipient,
                 from_=sender,
                 body=body,
                 status_callback=status_callback_url,
             )
+            if media_urls:
+                message_kwargs['media_url'] = media_urls
+            message = client.messages.create(**message_kwargs)
             if message.error_code:
                 return False
             logger.info('Message to %s is sent.', recipient)
@@ -502,9 +595,25 @@ class ConnectMessage(models.Model):
                 self.chatter_post(message.res_model, message.res_id, connect_partner.id, chatter_message)
             if vals:
                 message.write(vals)
+            message._bus_send_connect_status()
         except Exception as e:
             logger.warning('Failed to update message status for %s: %s', sid, e)
         return True
+
+    def _bus_send_connect_status(self):
+        for message in self.filtered(lambda rec: rec.channel_message_id and rec.channel_id):
+            if release.version_info[0] >= 17:
+                Store(bus_channel=message.channel_id).add(
+                    message.channel_message_id,
+                    {'connectStatus': message.status},
+                ).bus_send()
+            else:
+                self.env['bus.bus'].sudo()._sendone(
+                    message.channel_id,
+                    'mail.message/insert',
+                    {'id': message.channel_message_id.id,
+                     'connectStatus': message.status},
+                )
 
     def chatter_post(self, res_model, res_id, author, body):
         try:

--- a/connect/models/res_users.py
+++ b/connect/models/res_users.py
@@ -85,3 +85,12 @@ class ResUser(models.Model):
                 })
 
         return True
+
+
+class ResUsersSettings(models.Model):
+    _inherit = 'res.users.settings'
+
+    is_discuss_sidebar_category_connect_messages_open = fields.Boolean(
+        string='Is discuss sidebar category connect messages open?',
+        default=True,
+    )

--- a/connect/models/res_users.py
+++ b/connect/models/res_users.py
@@ -90,7 +90,10 @@ class ResUser(models.Model):
 class ResUsersSettings(models.Model):
     _inherit = 'res.users.settings'
 
+    # Persisted open/closed state of the "Messages" (connect_messages) Discuss
+    # sidebar category. The category's serverStateKey in the JS points at this
+    # field name; without it the collapse toggle has nothing to read/persist, so
+    # the category header doesn't expand/collapse like the built-in channel/chat
+    # categories. Default True => starts expanded, matching the built-ins.
     is_discuss_sidebar_category_connect_messages_open = fields.Boolean(
-        string='Is discuss sidebar category connect messages open?',
-        default=True,
-    )
+        string="Is discuss sidebar category connect messages open?", default=True)

--- a/connect/models/whatsapp_sender.py
+++ b/connect/models/whatsapp_sender.py
@@ -233,7 +233,9 @@ class ConnectWhatsappSender(models.Model):
         any_sender = self.search([('status', '=', 'ONLINE'), ('no_sync', '=', False)], limit=1)
         return any_sender
 
-    def send_whatsapp(self, recipient, body, res_model=None, res_id=None, raise_on_error=True, content_sid=None, content_variables=None):
+    def send_whatsapp(self, recipient, body, res_model=None, res_id=None,
+                      raise_on_error=True, content_sid=None,
+                      content_variables=None, skip_chatter=False):
         """Send a WhatsApp message using this sender and create connect.message + chatter.
 
         Args:
@@ -253,9 +255,9 @@ class ConnectWhatsappSender(models.Model):
             raise ValidationError('WhatsApp sender has no number configured.')
         # Check 24-hour window for WhatsApp - only if not using a content template
         if not content_sid:
-            # Find last incoming WhatsApp message from this recipient
+            # Numbers are stored without Twilio's ``whatsapp:`` scheme.
             last_incoming = self.env['connect.message'].sudo().search([
-                ('message_type', '=', 'WhatsApp'),
+                ('message_type', '=', 'whatsapp'),
                 ('from_number', '=', recipient),
                 ('direction', '=', 'incoming')
             ], order='create_date desc', limit=1)
@@ -306,7 +308,7 @@ class ConnectWhatsappSender(models.Model):
         sender_user = self.env.user
         partner = self.env['res.partner'].get_partner_by_number(recipient)
         msg_vals = {
-            'message_type': 'WhatsApp',
+            'message_type': 'whatsapp',
             'to_number': recipient,
             'from_number': self.number,
             'body': body,
@@ -325,10 +327,24 @@ class ConnectWhatsappSender(models.Model):
         msg = self.env['connect.message'].sudo().create(msg_vals)
 
         # Post to chatter if relevant
-        if res_model and res_id:
+        if res_model and res_id and not skip_chatter:
             chatter_message = Markup(f"<div class='d-flex flex-row'>"
                                      f"<p class='px-1'>{body}</p></div>")
             self.chatter_post(res_model, res_id, self.env.user.partner_id.id, chatter_message)
+        if not skip_chatter:
+            try:
+                channel_model = (
+                    'discuss.channel'
+                    if release.version_info[0] >= 17
+                    else 'mail.channel'
+                )
+                channel = self.env[channel_model]._get_connect_channel(
+                    partner, number=recipient, provider='whatsapp',
+                    create_if_not_found=False)
+                if channel:
+                    channel._connect_post_outbound(msg)
+            except Exception as e:
+                logger.warning('Connect Discuss outbound mirror failed: %s', e)
         return msg
 
     def chatter_post(self, res_model, res_id, author, body):
@@ -393,6 +409,7 @@ class ConnectWhatsappSender(models.Model):
                 self.chatter_post(message.res_model, message.res_id, connect_partner.id, chatter_message)
             if vals:
                 message.write(vals)
+            message._bus_send_connect_status()
         except Exception as e:
             logger.warning('Failed to update message status for %s: %s', sid, e)
         return True

--- a/connect/models/whatsapp_sender.py
+++ b/connect/models/whatsapp_sender.py
@@ -233,9 +233,7 @@ class ConnectWhatsappSender(models.Model):
         any_sender = self.search([('status', '=', 'ONLINE'), ('no_sync', '=', False)], limit=1)
         return any_sender
 
-    def send_whatsapp(self, recipient, body, res_model=None, res_id=None,
-                      raise_on_error=True, content_sid=None,
-                      content_variables=None, skip_chatter=False):
+    def send_whatsapp(self, recipient, body, res_model=None, res_id=None, raise_on_error=True, content_sid=None, content_variables=None, skip_chatter=False):
         """Send a WhatsApp message using this sender and create connect.message + chatter.
 
         Args:
@@ -255,7 +253,7 @@ class ConnectWhatsappSender(models.Model):
             raise ValidationError('WhatsApp sender has no number configured.')
         # Check 24-hour window for WhatsApp - only if not using a content template
         if not content_sid:
-            # Numbers are stored without Twilio's ``whatsapp:`` scheme.
+            # Find last incoming WhatsApp message from this recipient (clean number).
             last_incoming = self.env['connect.message'].sudo().search([
                 ('message_type', '=', 'whatsapp'),
                 ('from_number', '=', recipient),
@@ -331,6 +329,9 @@ class ConnectWhatsappSender(models.Model):
             chatter_message = Markup(f"<div class='d-flex flex-row'>"
                                      f"<p class='px-1'>{body}</p></div>")
             self.chatter_post(res_model, res_id, self.env.user.partner_id.id, chatter_message)
+        # Mirror an outbound sent from a record's chatter into the existing Discuss
+        # thread (only when one already exists). The Discuss-composer path passes
+        # skip_chatter=True and already posts into the channel itself.
         if not skip_chatter:
             try:
                 channel_model = (
@@ -409,6 +410,7 @@ class ConnectWhatsappSender(models.Model):
                 self.chatter_post(message.res_model, message.res_id, connect_partner.id, chatter_message)
             if vals:
                 message.write(vals)
+            # ODU-37: push status onto the Discuss bubble if mirrored.
             message._bus_send_connect_status()
         except Exception as e:
             logger.warning('Failed to update message status for %s: %s', sid, e)

--- a/connect/security/discuss_messages.xml
+++ b/connect/security/discuss_messages.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="rule_connect_messages_channel" model="ir.rule">
+        <field name="name">Connect: customer message channels for agents</field>
+        <field name="model_id" ref="mail.model_mail_channel"/>
+        <field name="domain_force">
+            ['|', ('channel_type', '!=', 'connect_messages'),
+             ('channel_partner_ids', 'in', [user.partner_id.id])]
+        </field>
+        <field name="groups" eval="[(4, ref('connect.group_connect_user'))]"/>
+    </record>
+</odoo>

--- a/connect/static/src/mail15/connect_messaging.scss
+++ b/connect/static/src/mail15/connect_messaging.scss
@@ -1,0 +1,13 @@
+.o_DiscussSidebar_categoryConnectMessages {
+    .o_DiscussSidebarCategoryItem_commandUnpin::before {
+        content: "\f187";
+    }
+}
+
+.o_connect_messages_header {
+    min-height: 24px;
+}
+
+.o_connect_message_status {
+    font-size: 0.75rem;
+}

--- a/connect/static/src/mail15/connect_messaging.xml
+++ b/connect/static/src/mail15/connect_messaging.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.DiscussSidebar" t-inherit-mode="extension" owl="1">
+        <xpath expr="//DiscussSidebarCategory[@categoryLocalId='discuss.categoryChannel.localId']" position="after">
+            <DiscussSidebarCategory
+                class="o_DiscussSidebar_category o_DiscussSidebar_categoryConnectMessages"
+                categoryLocalId="discuss.categoryConnectMessages.localId"
+            />
+        </xpath>
+    </t>
+
+    <t t-inherit="mail.Composer" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[hasclass('o_Composer_coreMain')]" position="before">
+            <div t-if="composerView.composer.thread.channel_type === 'connect_messages'"
+                 class="o_connect_messages_header d-flex align-items-center mb-2 px-2">
+                <i t-if="composerView.composer.thread.connectChannelProvider === 'whatsapp'"
+                   class="fa fa-whatsapp text-success mr-2" title="WhatsApp"/>
+                <span class="text-muted text-truncate mr-2"
+                      t-esc="composerView.composer.thread.connectNumber"/>
+                <button t-if="!composerView.composer.thread.connectPartnerId"
+                        class="btn btn-sm btn-link p-0 mr-2" type="button"
+                        t-on-click="composerView.onClickConnectCreatePartner">
+                    Create Contact
+                </button>
+                <button t-if="composerView.composer.thread.connectPartnerId"
+                        class="btn btn-sm btn-link p-0 mr-2" type="button"
+                        t-on-click="composerView.onClickConnectOpenPartner">
+                    Open Contact
+                </button>
+                <button class="btn btn-sm btn-link p-0 ml-auto" type="button"
+                        t-on-click="composerView.onClickConnectArchive">
+                    <i class="fa fa-archive mr-1"/>Archive
+                </button>
+            </div>
+            <div t-if="composerView.composer.thread.channel_type === 'connect_messages' and composerView.composer.thread.connectChannelProvider === 'whatsapp' and !composerView.composer.thread.connectWhatsappWindowOpen"
+                 class="alert alert-warning py-1 px-2 mb-2">
+                WhatsApp 24h window closed — send a template from the contact form.
+            </div>
+        </xpath>
+        <xpath expr="//div[hasclass('o_Composer_primaryToolButtons')]" position="inside">
+            <button class="o_Composer_button o_Composer_toolButton btn btn-light fa fa-microchip"
+                    title="AI Completion" aria-label="AI Completion" type="button"
+                    t-on-click="composerView.onClickAiCompletion"/>
+        </xpath>
+    </t>
+
+    <t t-inherit="mail.DiscussSidebarCategoryItem" t-inherit-mode="extension" owl="1">
+        <xpath expr="//span[hasclass('o_DiscussSidebarCategoryItem_name')]" position="inside">
+            <i t-if="categoryItem.channel.connectChannelProvider === 'whatsapp'"
+               class="fa fa-whatsapp text-success ml-1" title="WhatsApp"/>
+        </xpath>
+    </t>
+
+    <t t-inherit="mail.Message" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[hasclass('o_Message_date')]" position="inside">
+            <span t-if="messageView.message.connectStatus"
+                  class="ml-2 text-muted o_connect_message_status"
+                  t-esc="messageView.message.connectStatus"/>
+        </xpath>
+    </t>
+</templates>

--- a/connect/static/src/mail15/connect_messaging_models.js
+++ b/connect/static/src/mail15/connect_messaging_models.js
@@ -1,0 +1,256 @@
+/** @odoo-module **/
+
+import {
+    registerClassPatchModel,
+    registerFieldPatchModel,
+    registerIdentifyingFieldsPatch,
+    registerInstancePatchModel,
+} from '@mail/model/model_core';
+import { attr, one2one } from '@mail/model/model_field';
+import { insertAndReplace } from '@mail/model/model_field_command';
+
+import { str_to_datetime } from 'web.time';
+
+
+registerFieldPatchModel('mail.discuss', 'connect_messages', {
+    categoryConnectMessages: one2one('mail.discuss_sidebar_category', {
+        inverse: 'discussAsConnectMessages',
+        isCausal: true,
+    }),
+});
+
+registerFieldPatchModel('mail.discuss_sidebar_category', 'connect_messages', {
+    discussAsConnectMessages: one2one('mail.discuss', {
+        inverse: 'categoryConnectMessages',
+        readonly: true,
+    }),
+});
+
+registerIdentifyingFieldsPatch(
+    'mail.discuss_sidebar_category',
+    'connect_messages',
+    identifyingFields => identifyingFields[0].push('discussAsConnectMessages'),
+);
+
+registerInstancePatchModel('mail.messaging_initializer', 'connect_messages', {
+    _initResUsersSettings(settings) {
+        this._super(settings);
+        this.messaging.discuss.update({
+            categoryConnectMessages: insertAndReplace({
+                hasAddCommand: false,
+                hasViewCommand: false,
+                isServerOpen: settings.is_discuss_sidebar_category_connect_messages_open,
+                name: this.env._t('Messages'),
+                serverStateKey: 'is_discuss_sidebar_category_connect_messages_open',
+                sortComputeMethod: 'last_action',
+                supportedChannelTypes: ['connect_messages'],
+            }),
+        });
+    },
+});
+
+registerInstancePatchModel('mail.messaging_notification_handler', 'connect_messages', {
+    _handleNotificationResUsersSettings(settings) {
+        const result = this._super(settings);
+        if ('is_discuss_sidebar_category_connect_messages_open' in settings) {
+            this.messaging.discuss.categoryConnectMessages.update({
+                isServerOpen: settings.is_discuss_sidebar_category_connect_messages_open,
+            });
+        }
+        return result;
+    },
+});
+
+registerClassPatchModel('mail.thread', 'connect_messages', {
+    convertData(data) {
+        const converted = this._super(data);
+        if ('connect_partner_id' in data) {
+            converted.connectPartnerId = data.connect_partner_id || false;
+        }
+        if ('connect_number' in data) {
+            converted.connectNumber = data.connect_number;
+        }
+        if ('connect_channel_provider' in data) {
+            converted.connectChannelProvider = data.connect_channel_provider || 'sms';
+        }
+        if ('connect_whatsapp_window_open' in data) {
+            converted.connectWhatsappWindowOpen = data.connect_whatsapp_window_open;
+        }
+        if ('connect_whatsapp_valid_until' in data) {
+            converted.connectWhatsappValidUntil = data.connect_whatsapp_valid_until
+                ? str_to_datetime(data.connect_whatsapp_valid_until)
+                : false;
+        }
+        return converted;
+    },
+});
+
+registerInstancePatchModel('mail.thread', 'connect_messages', {
+    _getDiscussSidebarCategory() {
+        if (this.channel_type === 'connect_messages') {
+            return this.messaging.discuss.categoryConnectMessages;
+        }
+        return this._super();
+    },
+});
+
+registerFieldPatchModel('mail.thread', 'connect_messages', {
+    connectPartnerId: attr({ default: false }),
+    connectNumber: attr(),
+    connectChannelProvider: attr({ default: 'sms' }),
+    connectWhatsappWindowOpen: attr({ default: false }),
+    connectWhatsappValidUntil: attr(),
+});
+
+registerClassPatchModel('mail.message', 'connect_messages', {
+    convertData(data) {
+        const converted = this._super(data);
+        if ('connectStatus' in data) {
+            converted.connectStatus = data.connectStatus;
+        }
+        if ('connectMessageType' in data) {
+            converted.connectMessageType = data.connectMessageType;
+        }
+        return converted;
+    },
+});
+
+registerFieldPatchModel('mail.message', 'connect_messages', {
+    connectStatus: attr(),
+    connectMessageType: attr(),
+});
+
+registerInstancePatchModel('mail.composer', 'connect_messages', {
+    _computeCanPostMessage() {
+        const canPost = this._super();
+        const thread = this.thread;
+        if (
+            thread &&
+            thread.channel_type === 'connect_messages' &&
+            thread.connectChannelProvider === 'whatsapp' &&
+            !thread.connectWhatsappWindowOpen
+        ) {
+            return false;
+        }
+        return canPost;
+    },
+});
+
+registerInstancePatchModel('mail.composer_view', 'connect_messages', {
+    _created() {
+        const result = this._super();
+        this.onClickAiCompletion = this.onClickAiCompletion.bind(this);
+        this.onClickConnectArchive = this.onClickConnectArchive.bind(this);
+        this.onClickConnectCreatePartner = this.onClickConnectCreatePartner.bind(this);
+        this.onClickConnectOpenPartner = this.onClickConnectOpenPartner.bind(this);
+        return result;
+    },
+    _getMessageData() {
+        const data = this._super();
+        const thread = this.composer.thread;
+        if (thread && thread.channel_type === 'connect_messages') {
+            data.message_type = 'connect_message';
+            data.connect_provider = thread.connectChannelProvider || 'sms';
+        }
+        return data;
+    },
+    async onClickAiCompletion() {
+        const thread = this.composer.thread;
+        const response = await this.env.services.rpc({
+            route: '/connect/ai_completion',
+            params: { model: thread.model, res_id: thread.id },
+        });
+        if (response.status === 'ok') {
+            this.composer.update({ textInputContent: response.message });
+        } else {
+            this.env.services.notification.notify({
+                message: response.error_message,
+                type: 'warning',
+            });
+        }
+    },
+    async onClickConnectArchive() {
+        const thread = this.composer.thread;
+        await this.env.services.rpc({
+            model: 'mail.channel',
+            method: 'channel_pin',
+            args: [thread.uuid],
+            kwargs: { pinned: false },
+        });
+    },
+    async onClickConnectCreatePartner() {
+        const thread = this.composer.thread;
+        const result = await this.env.services.rpc({
+            model: 'mail.channel',
+            method: 'connect_create_partner',
+            args: [[thread.id]],
+        });
+        if (result && result.partner_id) {
+            thread.update({ connectPartnerId: result.partner_id });
+            this.env.services.notification.notify({
+                message: _.str.sprintf(
+                    this.env._t('Contact created: %s'), result.partner_name),
+                type: 'success',
+            });
+        }
+    },
+    onClickConnectOpenPartner() {
+        const thread = this.composer.thread;
+        return this.env.bus.trigger('do-action', {
+            action: {
+                type: 'ir.actions.act_window',
+                res_model: 'res.partner',
+                res_id: thread.connectPartnerId,
+                views: [[false, 'form']],
+            },
+        });
+    },
+});
+
+registerInstancePatchModel('mail.discuss_sidebar_category_item', 'connect_messages', {
+    _computeAvatarUrl() {
+        if (this.channelType === 'connect_messages') {
+            if (this.channel.connectPartnerId) {
+                return `/web/image/res.partner/${this.channel.connectPartnerId}/avatar_128`;
+            }
+            return '/mail/static/src/img/smiley/avatar.jpg';
+        }
+        return this._super();
+    },
+    _computeCategoryCounterContribution() {
+        if (this.channelType === 'connect_messages') {
+            return this.channel.localMessageUnreadCounter > 0 ? 1 : 0;
+        }
+        return this._super();
+    },
+    _computeCounter() {
+        if (this.channelType === 'connect_messages') {
+            return this.channel.localMessageUnreadCounter;
+        }
+        return this._super();
+    },
+    _computeHasLeaveCommand() {
+        if (this.channelType === 'connect_messages') {
+            return false;
+        }
+        return this._super();
+    },
+    _computeHasSettingsCommand() {
+        if (this.channelType === 'connect_messages') {
+            return false;
+        }
+        return this._super();
+    },
+    _computeHasThreadIcon() {
+        if (this.channelType === 'connect_messages') {
+            return false;
+        }
+        return this._super();
+    },
+    _computeHasUnpinCommand() {
+        if (this.channelType === 'connect_messages') {
+            return !this.channel.localMessageUnreadCounter;
+        }
+        return this._super();
+    },
+});

--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import test_s3_utils
 from . import test_s3_settings
+from . import test_connect_discuss_channel

--- a/connect/tests/test_connect_discuss_channel.py
+++ b/connect/tests/test_connect_discuss_channel.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+from datetime import timedelta
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+
+class TestConnectDiscussChannel(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Channel = cls.env['mail.channel']
+        cls.Message = cls.env['connect.message']
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Connect Customer',
+            'phone': '+12125550123',
+        })
+
+    def _make_message(self, suffix='1', **values):
+        vals = {
+            'message_sid': 'SM%s' % suffix,
+            'from_number': '+12125550123',
+            'to_number': '+12125550000',
+            'body': 'Hello',
+            'message_type': 'sms',
+            'status': 'received',
+            'partner': self.partner.id,
+        }
+        vals.update(values)
+        return self.Message.sudo().create(vals)
+
+    def test_partner_channel_is_created_and_reused(self):
+        channel = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            provider='sms',
+            create_if_not_found=True,
+        )
+        reused = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            provider='sms',
+            create_if_not_found=True,
+        )
+        self.assertEqual(channel, reused)
+        self.assertEqual(channel.channel_type, 'connect_messages')
+        self.assertEqual(channel.connect_partner_id, self.partner)
+        self.assertEqual(channel.connect_number, '+12125550123')
+        self.assertIn(self.partner, channel.channel_partner_ids)
+
+    def test_number_only_channel_and_contact_creation(self):
+        number = '+12125550999'
+        channel = self.Channel._get_connect_channel(
+            self.env['res.partner'],
+            number=number,
+            provider='whatsapp',
+            create_if_not_found=True,
+        )
+        self.assertFalse(channel.connect_partner_id)
+        self.assertEqual(channel.connect_number, number)
+        self.assertEqual(channel.connect_channel_provider, 'whatsapp')
+
+        result = channel.connect_create_partner('New Customer')
+        self.assertTrue(result['partner_id'])
+        self.assertEqual(channel.connect_partner_id.id, result['partner_id'])
+        self.assertEqual(channel.connect_partner_id.phone, number)
+        self.assertIn(channel.connect_partner_id, channel.channel_partner_ids)
+
+    def test_inbound_message_is_mirrored_and_formatted(self):
+        channel = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            create_if_not_found=True,
+        )
+        connect_message = self._make_message()
+        mail_message = channel._connect_post_inbound(connect_message)
+
+        self.assertEqual(connect_message.channel_id, channel)
+        self.assertEqual(connect_message.channel_message_id, mail_message)
+        self.assertEqual(mail_message.connect_message, connect_message)
+        self.assertEqual(mail_message.message_type, 'connect_message')
+        formatted = mail_message.message_format()[0]
+        self.assertEqual(formatted['connectStatus'], 'received')
+        self.assertEqual(formatted['connectMessageType'], 'sms')
+
+    def test_whatsapp_window_uses_last_inbound_message(self):
+        channel = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            provider='whatsapp',
+            create_if_not_found=True,
+        )
+        connect_message = self._make_message(
+            suffix='wa', message_type='whatsapp')
+        mail_message = channel._connect_post_inbound(connect_message)
+        channel.invalidate_cache()
+
+        self.assertEqual(channel.connect_last_inbound_whatsapp_id, mail_message)
+        self.assertTrue(channel.connect_whatsapp_window_open)
+        self.assertGreater(
+            channel.connect_whatsapp_valid_until,
+            fields.Datetime.now(),
+        )
+
+    def test_outbound_discuss_post_calls_connect_sender(self):
+        channel = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            create_if_not_found=True,
+        )
+        sent = self._make_message(
+            suffix='out',
+            from_number='+12125550000',
+            to_number='+12125550123',
+            status='sent',
+            sender_user=self.env.user.id,
+        )
+        with patch.object(type(self.Message), 'send', return_value=sent) as send:
+            message = channel.message_post(
+                body='Reply',
+                message_type='connect_message',
+                subtype_xmlid='mail.mt_comment',
+                connect_provider='sms',
+            )
+        self.assertTrue(send.called)
+        self.assertEqual(sent.channel_id, channel)
+        self.assertEqual(sent.channel_message_id, message)
+
+    def test_archived_channel_resurfaces(self):
+        channel = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            create_if_not_found=True,
+        )
+        member = channel.channel_last_seen_partner_ids.filtered(
+            lambda rec: rec.partner_id == self.env.user.partner_id)
+        self.assertTrue(member)
+        member.write({'is_pinned': False})
+        channel._connect_resurface()
+        self.assertTrue(member.is_pinned)
+
+    def test_connect_sidebar_setting_exists(self):
+        settings_model = self.env['res.users.settings']
+        self.assertIn(
+            'is_discuss_sidebar_category_connect_messages_open',
+            settings_model._fields,
+        )
+        settings = settings_model._find_or_create_for_user(self.env.user)
+        self.assertTrue(settings.is_discuss_sidebar_category_connect_messages_open)
+        settings.set_res_users_settings({
+            'is_discuss_sidebar_category_connect_messages_open': False,
+        })
+        self.assertFalse(
+            settings.is_discuss_sidebar_category_connect_messages_open)
+
+    def test_clean_number_and_provider_are_normalized(self):
+        values = self.Message.get_receive_message_values({
+            'MessageSid': 'WA1',
+            'From': 'whatsapp:+12125550123',
+            'To': 'whatsapp:+12125550000',
+            'Body': 'Hello',
+            'NumMedia': '0',
+            'SmsStatus': 'received',
+        })
+        self.assertEqual(values['from_number'], '+12125550123')
+        self.assertEqual(values['to_number'], '+12125550000')
+        self.assertEqual(values['message_type'], 'whatsapp')
+
+    def test_idle_read_channels_are_unpinned(self):
+        channel = self.Channel._get_connect_channel(
+            self.partner,
+            number='+12125550123',
+            create_if_not_found=True,
+        )
+        member = channel.channel_last_seen_partner_ids.filtered(
+            lambda rec: rec.partner_id == self.env.user.partner_id)
+        member.write({
+            'is_pinned': True,
+            'last_interest_dt': fields.Datetime.now() - timedelta(days=2),
+        })
+        self.env['mail.channel.partner']._gc_unpin_connect_channels()
+        self.assertFalse(member.is_pinned)

--- a/connect/tests/test_connect_discuss_channel.py
+++ b/connect/tests/test_connect_discuss_channel.py
@@ -1,184 +1,533 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
-from unittest.mock import patch
-
-from odoo import fields
+from odoo import release
 from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
 
 
+def _flatten_store(data):
+    out = []
+    for value in (data or {}).values():
+        if isinstance(value, list):
+            out.extend(v for v in value if isinstance(v, dict))
+        elif isinstance(value, dict):
+            out.append(value)
+    return out
+
+
+@tagged("post_install", "-at_install")
 class TestConnectDiscussChannel(TransactionCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.Channel = cls.env['mail.channel']
-        cls.Message = cls.env['connect.message']
+        cls.Channel = cls.env[
+            'discuss.channel' if release.version_info[0] >= 17 else 'mail.channel'
+        ]
         cls.partner = cls.env['res.partner'].create({
-            'name': 'Connect Customer',
-            'phone': '+12125550123',
+            'name': 'Acme Customer', 'phone': '+15551230000',
+        })
+        # An internal agent user in the Connect User group (internal user is
+        # required to create mail.message records when posting in the channel).
+        cls.agent = cls.env['res.users'].create({
+            'name': 'Agent A', 'login': 'agent_a',
+            'group_ids' if release.version_info[0] >= 18 else 'groups_id': [
+                (4, cls.env.ref('base.group_user').id),
+                (4, cls.env.ref('connect.group_connect_user').id),
+            ],
         })
 
-    def _make_message(self, suffix='1', **values):
-        vals = {
-            'message_sid': 'SM%s' % suffix,
-            'from_number': '+12125550123',
-            'to_number': '+12125550000',
-            'body': 'Hello',
-            'message_type': 'sms',
-            'status': 'received',
-            'partner': self.partner.id,
-        }
-        vals.update(values)
-        return self.Message.sudo().create(vals)
+    def _make_incoming(self, body='hi there', mtype='sms', number='+15551230000'):
+        return self.env['connect.message'].sudo().create({
+            'message_sid': 'SM' + body[:6], 'from_number': number,
+            'to_number': '+15550000000', 'body': body, 'message_type': mtype,
+            'status': 'received', 'partner': self.partner.id,
+        })
 
-    def test_partner_channel_is_created_and_reused(self):
-        channel = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            provider='sms',
-            create_if_not_found=True,
-        )
-        reused = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            provider='sms',
-            create_if_not_found=True,
-        )
-        self.assertEqual(channel, reused)
-        self.assertEqual(channel.channel_type, 'connect_messages')
-        self.assertEqual(channel.connect_partner_id, self.partner)
-        self.assertEqual(channel.connect_number, '+12125550123')
-        self.assertIn(self.partner, channel.channel_partner_ids)
+    def test_get_connect_channel_is_idempotent(self):
+        ch1 = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        ch2 = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        self.assertEqual(ch1, ch2, "Must reuse the one per-partner channel")
+        self.assertEqual(ch1.channel_type, 'connect_messages')
+        self.assertEqual(ch1.connect_partner_id, self.partner)
 
-    def test_number_only_channel_and_contact_creation(self):
-        number = '+12125550999'
-        channel = self.Channel._get_connect_channel(
-            self.env['res.partner'],
-            number=number,
-            provider='whatsapp',
-            create_if_not_found=True,
+    def test_get_connect_channel_adds_agents_and_customer(self):
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        member_partners = (
+            ch.channel_member_ids.partner_id
+            if release.version_info[0] >= 17
+            else ch.channel_last_seen_partner_ids.partner_id
         )
-        self.assertFalse(channel.connect_partner_id)
-        self.assertEqual(channel.connect_number, number)
-        self.assertEqual(channel.connect_channel_provider, 'whatsapp')
+        self.assertIn(self.agent.partner_id, member_partners)
+        self.assertIn(self.partner, member_partners)
 
-        result = channel.connect_create_partner('New Customer')
+    def test_get_connect_channel_no_create(self):
+        ch = self.Channel._get_connect_channel(self.partner)
+        self.assertFalse(ch)
+
+    def test_send_returns_connect_message(self):
+        from unittest.mock import patch
+
+        class _Fake:
+            sid = 'SMtest'
+            account_sid = 'ACtest'
+            messaging_service_sid = False
+            num_media = 0
+            error_code = None
+            error_message = None
+
+        with patch.object(type(self.env['connect.message']), 'client_send', return_value=_Fake()):
+            msg = self.env['connect.message'].with_user(self.agent).send(
+                '+15551230000', 'hello', res_id=self.partner.id, res_model='res.partner',
+                outgoing_callerid='+15550000000')
+        self.assertTrue(msg, "send() must return the created connect.message")
+        self.assertEqual(msg.to_number, '+15551230000')
+        self.assertIn('mail_message_id', msg._fields)
+        self.assertIn('channel_id', msg._fields)
+
+    def test_inbound_mirror_posts_to_channel(self):
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        cmsg = self._make_incoming('inbound one')
+        msg = ch._connect_post_inbound(cmsg)
+        self.assertEqual(msg.message_type, 'connect_message')
+        self.assertEqual(msg.author_id, self.partner)
+        self.assertEqual(cmsg.channel_message_id, msg)
+        self.assertEqual(cmsg.channel_id, ch)
+        self.assertIn(msg, ch.message_ids)
+
+    def test_inbound_whatsapp_stores_clean_number_and_provider(self):
+        Msg = self.env['connect.message']
+        vals = Msg.get_receive_message_values({
+            'From': 'whatsapp:+15551230000', 'To': 'whatsapp:+15550000000',
+            'Body': 'hi', 'MessageSid': 'SMwa', 'NumMedia': '0',
+        })
+        self.assertEqual(vals['message_type'], 'whatsapp')
+        self.assertEqual(vals['from_number'], '+15551230000')
+        self.assertEqual(vals['to_number'], '+15550000000')
+
+    def test_inbound_sms_unchanged(self):
+        Msg = self.env['connect.message']
+        vals = Msg.get_receive_message_values({
+            'From': '+15551230000', 'To': '+15550000000',
+            'Body': 'hi', 'MessageSid': 'SMsms', 'NumMedia': '0',
+        })
+        self.assertEqual(vals['message_type'], 'sms')
+        self.assertEqual(vals['from_number'], '+15551230000')
+
+    def test_provider_helper(self):
+        Msg = self.env['connect.message']
+        wa = Msg.sudo().create({'message_sid': 'SMp1', 'from_number': '+1',
+            'to_number': '+2', 'body': 'x', 'message_type': 'whatsapp', 'status': 'received'})
+        sms = Msg.sudo().create({'message_sid': 'SMp2', 'from_number': '+1',
+            'to_number': '+2', 'body': 'x', 'message_type': 'mms', 'status': 'received'})
+        self.assertEqual(wa._provider(), 'whatsapp')
+        self.assertEqual(sms._provider(), 'sms')
+
+    def test_inbound_whatsapp_sets_window(self):
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        cmsg = self._make_incoming('wa hello', mtype='whatsapp')
+        msg = ch._connect_post_inbound(cmsg)
+        self.assertEqual(ch.connect_last_inbound_whatsapp_id, msg)
+        self.assertTrue(ch.connect_whatsapp_window_open)
+
+    def test_outbound_post_sends_sms_and_links(self):
+        from unittest.mock import patch
+
+        class _Fake:
+            sid = 'SMout'; account_sid = 'ACtest'; messaging_service_sid = False
+            num_media = 0; error_code = None; error_message = None
+
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        with patch.object(type(self.env['connect.message']), 'client_send', return_value=_Fake()):
+            msg = ch.with_user(self.agent).message_post(
+                body='reply text', message_type='connect_message',
+                connect_provider='sms', connect_sender_id='+15550000000')
+        cmsg = self.env['connect.message'].search([('channel_message_id', '=', msg.id)])
+        self.assertTrue(cmsg, "Outbound must create a linked connect.message")
+        self.assertEqual(cmsg.to_number, '+15551230000')
+        self.assertEqual(cmsg.channel_id, ch)
+
+    def test_inbound_mirror_does_not_send(self):
+        from unittest.mock import patch
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        cmsg_in = self._make_incoming('inbound no send')
+        with patch.object(type(self.env['connect.message']), 'client_send') as cs:
+            ch._connect_post_inbound(cmsg_in)
+            cs.assert_not_called()
+
+    def test_outbound_media_urls_built_from_attachments(self):
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        att = self.env['ir.attachment'].create({
+            'name': 'pic.png', 'datas': 'aGVsbG8=', 'mimetype': 'image/png'})
+        msg = self.env['mail.message'].create({
+            'model': ch._name, 'res_id': ch.id, 'message_type': 'connect_message',
+            'attachment_ids': [(4, att.id)]})
+        urls = ch._connect_media_urls(msg)
+        self.assertEqual(len(urls), 1)
+        self.assertIn('/web/content/%d' % att.id, urls[0])
+        self.assertIn('access_token=', urls[0])
+
+    def test_number_only_channel_created_when_no_partner(self):
+        """_get_connect_channel creates a phone-number-only channel when partner is falsy."""
+        unknown_number = '+19995550001'
+        ch = self.Channel._get_connect_channel(
+            self.env['res.partner'], number=unknown_number, create_if_not_found=True)
+        self.assertTrue(ch, "Must create a channel even without a partner")
+        self.assertEqual(ch.channel_type, 'connect_messages')
+        self.assertFalse(ch.connect_partner_id)
+        self.assertEqual(ch.connect_number, unknown_number)
+        self.assertEqual(ch.name, unknown_number)
+
+    def test_number_only_channel_is_idempotent(self):
+        unknown_number = '+19995550002'
+        ch1 = self.Channel._get_connect_channel(
+            self.env['res.partner'], number=unknown_number, create_if_not_found=True)
+        ch2 = self.Channel._get_connect_channel(
+            self.env['res.partner'], number=unknown_number, create_if_not_found=True)
+        self.assertEqual(ch1, ch2, "Must reuse the existing number-only channel")
+
+    def test_connect_create_partner_links_channel(self):
+        unknown_number = '+19995550003'
+        ch = self.Channel._get_connect_channel(
+            self.env['res.partner'], number=unknown_number, create_if_not_found=True)
+        result = ch.connect_create_partner(partner_name='New Customer')
         self.assertTrue(result['partner_id'])
-        self.assertEqual(channel.connect_partner_id.id, result['partner_id'])
-        self.assertEqual(channel.connect_partner_id.phone, number)
-        self.assertIn(channel.connect_partner_id, channel.channel_partner_ids)
-
-    def test_inbound_message_is_mirrored_and_formatted(self):
-        channel = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            create_if_not_found=True,
+        self.assertEqual(result['partner_name'], 'New Customer')
+        # Channel must now be linked to the partner.
+        self.assertEqual(ch.connect_partner_id.id, result['partner_id'])
+        self.assertEqual(ch.name, 'New Customer')
+        partner = self.env['res.partner'].browse(result['partner_id'])
+        member_partners = (
+            ch.channel_member_ids.partner_id
+            if release.version_info[0] >= 17
+            else ch.channel_last_seen_partner_ids.partner_id
         )
-        connect_message = self._make_message()
-        mail_message = channel._connect_post_inbound(connect_message)
+        self.assertIn(partner, member_partners)
+        # New contact gets the default mail "smiley" avatar.
+        self.assertTrue(partner.image_1920, "new contact must get a default avatar")
 
-        self.assertEqual(connect_message.channel_id, channel)
-        self.assertEqual(connect_message.channel_message_id, mail_message)
-        self.assertEqual(mail_message.connect_message, connect_message)
-        self.assertEqual(mail_message.message_type, 'connect_message')
-        formatted = mail_message.message_format()[0]
-        self.assertEqual(formatted['connectStatus'], 'received')
-        self.assertEqual(formatted['connectMessageType'], 'sms')
-
-    def test_whatsapp_window_uses_last_inbound_message(self):
-        channel = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            provider='whatsapp',
-            create_if_not_found=True,
-        )
-        connect_message = self._make_message(
-            suffix='wa', message_type='whatsapp')
-        mail_message = channel._connect_post_inbound(connect_message)
-        channel.invalidate_cache()
-
-        self.assertEqual(channel.connect_last_inbound_whatsapp_id, mail_message)
-        self.assertTrue(channel.connect_whatsapp_window_open)
-        self.assertGreater(
-            channel.connect_whatsapp_valid_until,
-            fields.Datetime.now(),
-        )
-
-    def test_outbound_discuss_post_calls_connect_sender(self):
-        channel = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            create_if_not_found=True,
-        )
-        sent = self._make_message(
-            suffix='out',
-            from_number='+12125550000',
-            to_number='+12125550123',
-            status='sent',
-            sender_user=self.env.user.id,
-        )
-        with patch.object(type(self.Message), 'send', return_value=sent) as send:
-            message = channel.message_post(
-                body='Reply',
-                message_type='connect_message',
-                subtype_xmlid='mail.mt_comment',
-                connect_provider='sms',
-            )
-        self.assertTrue(send.called)
-        self.assertEqual(sent.channel_id, channel)
-        self.assertEqual(sent.channel_message_id, message)
-
-    def test_archived_channel_resurfaces(self):
-        channel = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            create_if_not_found=True,
-        )
-        member = channel.channel_last_seen_partner_ids.filtered(
-            lambda rec: rec.partner_id == self.env.user.partner_id)
-        self.assertTrue(member)
-        member.write({'is_pinned': False})
-        channel._connect_resurface()
-        self.assertTrue(member.is_pinned)
-
-    def test_connect_sidebar_setting_exists(self):
-        settings_model = self.env['res.users.settings']
-        self.assertIn(
-            'is_discuss_sidebar_category_connect_messages_open',
-            settings_model._fields,
-        )
-        settings = settings_model._find_or_create_for_user(self.env.user)
-        self.assertTrue(settings.is_discuss_sidebar_category_connect_messages_open)
-        settings.set_res_users_settings({
-            'is_discuss_sidebar_category_connect_messages_open': False,
+    def test_connect_create_partner_backfills_messages(self):
+        unknown_number = '+19995550004'
+        ch = self.Channel._get_connect_channel(
+            self.env['res.partner'], number=unknown_number, create_if_not_found=True)
+        msg = self.env['connect.message'].sudo().create({
+            'message_sid': 'SMbackfill', 'from_number': unknown_number,
+            'to_number': '+15550000000', 'body': 'test', 'message_type': 'sms',
+            'status': 'received',
         })
-        self.assertFalse(
-            settings.is_discuss_sidebar_category_connect_messages_open)
+        self.assertFalse(msg.partner)
+        ch.connect_create_partner(partner_name='Back Customer')
+        self.assertTrue(msg.partner)
 
-    def test_clean_number_and_provider_are_normalized(self):
-        values = self.Message.get_receive_message_values({
-            'MessageSid': 'WA1',
-            'From': 'whatsapp:+12125550123',
-            'To': 'whatsapp:+12125550000',
-            'Body': 'Hello',
-            'NumMedia': '0',
-            'SmsStatus': 'received',
+    def test_to_store_includes_connect_status(self):
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        cmsg = self._make_incoming('status check')
+        msg = ch._connect_post_inbound(cmsg)
+        cmsg.status = 'delivered'
+        if release.version_info[0] >= 17:
+            from odoo.addons.mail.tools.discuss import Store
+            store = Store()
+            store.add(msg)
+            data = store.get_result()
+            found = any('connectStatus' in rec for rec in _flatten_store(data))
+        else:
+            found = msg.message_format()[0].get('connectStatus') == 'delivered'
+        self.assertTrue(found)
+
+    def test_whatsapp_window_matches_inbound(self):
+        """Regression: a clean-number inbound WhatsApp lets a reply send within
+        the 24h window (the window lookup must match the stored clean number)."""
+        from unittest.mock import patch
+        sender = self.env['connect.whatsapp_sender'].create({
+            'number': '+15550000000', 'status': 'ONLINE'})
+        self.env['connect.message'].sudo().create({
+            'message_sid': 'WAin1', 'from_number': '+15551230000',
+            'to_number': '+15550000000', 'body': 'hi',
+            'message_type': 'whatsapp', 'status': 'received', 'partner': self.partner.id})
+
+        class _Msg:
+            sid = 'WAout1'; account_sid = 'ACtest'; messaging_service_sid = False
+            num_media = 0; error_code = None; error_message = None
+        class _FakeMessages:
+            def create(self, **kwargs):
+                return _Msg()
+        class _FakeClient:
+            messages = _FakeMessages()
+        with patch.object(type(self.env['oduist.license']), 'check_license', return_value=True), \
+             patch.object(type(self.env['connect.settings']), 'get_client', return_value=_FakeClient()):
+            msg = sender.send_whatsapp(recipient='+15551230000', body='reply')
+        self.assertTrue(msg)
+        self.assertEqual(msg.message_type, 'whatsapp')
+        self.assertEqual(msg.to_number, '+15551230000')
+
+    def test_whatsapp_window_raises_without_inbound(self):
+        """No prior inbound WhatsApp -> must refuse and ask for a template."""
+        from unittest.mock import patch
+        from odoo.exceptions import ValidationError
+
+        sender = self.env['connect.whatsapp_sender'].create({
+            'number': '+15550000001', 'status': 'ONLINE',
         })
-        self.assertEqual(values['from_number'], '+12125550123')
-        self.assertEqual(values['to_number'], '+12125550000')
-        self.assertEqual(values['message_type'], 'whatsapp')
+        with patch.object(type(self.env['oduist.license']), 'check_license', return_value=True):
+            with self.assertRaises(ValidationError):
+                sender.send_whatsapp(recipient='+19998887777', body='cold')
 
-    def test_idle_read_channels_are_unpinned(self):
-        channel = self.Channel._get_connect_channel(
-            self.partner,
-            number='+12125550123',
-            create_if_not_found=True,
+    def test_get_connect_channel_uses_explicit_provider(self):
+        # Number-only branch: provider comes from the argument, number stored clean.
+        ch = self.Channel._get_connect_channel(
+            self.env['res.partner'], number='+19995551111',
+            provider='whatsapp', create_if_not_found=True)
+        self.assertEqual(ch.connect_channel_provider, 'whatsapp')
+        self.assertEqual(ch.connect_number, '+19995551111')  # stored clean
+        # Partner-keyed branch (the actual bug site): provider also honoured.
+        pch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000',
+            provider='whatsapp', create_if_not_found=True)
+        self.assertEqual(pch.connect_channel_provider, 'whatsapp')
+        self.assertEqual(pch.connect_partner_id, self.partner)
+
+    def test_inbound_whatsapp_with_contact_reuses_channel(self):
+        from unittest.mock import patch
+        Msg = self.env['connect.message']
+        # Use a VALID number so phone_sanitized populates and get_partner_by_number
+        # resolves the contact (the fictional +1555... range does not sanitize).
+        number = '+12125550123'
+        cust = self.env['res.partner'].create({'name': 'WA Cust', 'phone': number})
+        self.assertTrue(cust.phone_sanitized, 'precondition: number must sanitize')
+        # Contact already linked to its connect_messages channel.
+        ch = self.Channel._get_connect_channel(
+            cust, number=number, provider='whatsapp', create_if_not_found=True)
+
+        def _gp(key, *a, **k):
+            return 'ACtest' if key == 'account_sid' else ''
+        params = {
+            'AccountSid': 'ACtest', 'SmsStatus': 'received',
+            'From': 'whatsapp:' + number, 'To': 'whatsapp:+15550000000',
+            'Body': 'second', 'MessageSid': 'SMsecond', 'NumMedia': '0',
+        }
+        # Run as the real webhook user (production identity) so the
+        # connect.message_configuration lookup in receive() does not AccessError
+        # and the Discuss mirror actually runs — otherwise this test passes
+        # vacuously without exercising the channel-reuse path.
+        webhook_user = self.env.ref('connect.user_connect_webhook')
+        with patch.object(type(self.env['oduist.license']), 'check_license', return_value=True), \
+             patch.object(type(self.env['connect.settings']), 'get_param', side_effect=_gp):
+            Msg.with_user(webhook_user).receive(params)
+
+        # Search by NUMBER, not partner: the bug created a number-only duplicate
+        # (connect_partner_id=False) which a partner-filtered search would miss.
+        channels = self.Channel.search([
+            ('channel_type', '=', 'connect_messages'),
+            ('connect_number', '=', number)])
+        self.assertEqual(channels, ch, "must reuse the existing channel, not create a duplicate")
+        msg = Msg.search([('message_sid', '=', 'SMsecond')])
+        self.assertEqual(msg.from_number, number)
+        self.assertEqual(msg.message_type, 'whatsapp')
+
+    def test_mail_message_type_maps_to_capitalized(self):
+        Msg = self.env['connect.message']
+        wa = Msg.sudo().create({'message_sid': 'SMm1', 'from_number': '+1',
+            'to_number': '+2', 'body': 'x', 'message_type': 'whatsapp', 'status': 'received'})
+        sms = Msg.sudo().create({'message_sid': 'SMm2', 'from_number': '+1',
+            'to_number': '+2', 'body': 'x', 'message_type': 'sms', 'status': 'received'})
+        # mail.message / mail.notification selections use the capitalized 'WhatsApp'.
+        self.assertEqual(wa._mail_message_type(), 'WhatsApp')
+        self.assertEqual(sms._mail_message_type(), 'sms')
+
+    def test_inbound_whatsapp_chatter_does_not_break_mirror(self):
+        """Regression: when receive() posts to the target record's chatter, the
+        mail.message message_type must use the mail convention ('WhatsApp'), not
+        the lowercase connect provider. Otherwise message_post raises 'Wrong value
+        for mail.message.message_type: whatsapp', receive() aborts, and the Discuss
+        mirror is skipped (channel_id stays NULL)."""
+        from unittest.mock import patch
+        Msg = self.env['connect.message']
+        number = '+12125550124'
+        our = '+15550000000'
+        cust = self.env['res.partner'].create({'name': 'WA Cust3', 'phone': number})
+        # A prior outbound linked to the partner's chatter makes the next inbound
+        # resolve a VALID target -> the chatter-post branch of receive() runs.
+        Msg.sudo().create({
+            'message_sid': 'SMprior', 'from_number': our, 'to_number': number,
+            'body': 'prior', 'message_type': 'whatsapp', 'status': 'sent',
+            'res_model': 'res.partner', 'res_id': cust.id, 'sender_user': self.agent.id,
+        })
+
+        def _gp(key, *a, **k):
+            return 'ACtest' if key == 'account_sid' else ''
+        params = {
+            'AccountSid': 'ACtest', 'SmsStatus': 'received',
+            'From': 'whatsapp:' + number, 'To': 'whatsapp:' + our,
+            'Body': 'inbound after', 'MessageSid': 'SMafter', 'NumMedia': '0',
+        }
+        webhook_user = self.env.ref('connect.user_connect_webhook')
+        with patch.object(type(self.env['oduist.license']), 'check_license', return_value=True), \
+             patch.object(type(self.env['connect.settings']), 'get_param', side_effect=_gp):
+            Msg.with_user(webhook_user).receive(params)
+
+        new = Msg.search([('message_sid', '=', 'SMafter')])
+        self.assertTrue(new.channel_id, "inbound must be mirrored to Discuss (channel_id set)")
+        self.assertTrue(new.mail_message_id, "inbound must have a mirrored mail.message")
+        # The contact-chatter post must be a quiet log note (mt_note), not a
+        # comment — a comment emails followers and yields a red delivery-failure
+        # envelope when no SMTP is configured.
+        self.assertEqual(new.mail_message_id.subtype_id, self.env.ref('mail.mt_note'))
+        # ...and carry a display-only WhatsApp notification so the note shows the
+        # WhatsApp logo (no email: is_read + 'ready' status).
+        wa_notif = new.mail_message_id.notification_ids.filtered(
+            lambda n: n.notification_type == 'WhatsApp')
+        self.assertTrue(wa_notif, "inbound note must carry a WhatsApp marker notification")
+        self.assertEqual(wa_notif.notification_status, 'ready')
+
+    def test_inbound_known_partner_copies_to_partner_chatter(self):
+        """Inbound from an existing partner (no prior thread record) still posts a
+        copy to the partner's own chatter, and mirrors into Discuss."""
+        from unittest.mock import patch
+        Msg = self.env['connect.message']
+        number = '+12125550133'
+        cust = self.env['res.partner'].create({'name': 'Copy Cust', 'phone': number})
+        self.assertTrue(cust.phone_sanitized, 'precondition: number must sanitize')
+
+        def _gp(key, *a, **k):
+            return 'ACtest' if key == 'account_sid' else ''
+        params = {
+            'AccountSid': 'ACtest', 'SmsStatus': 'received',
+            'From': number, 'To': '+15550000000',
+            'Body': 'hello there', 'MessageSid': 'SMcopy', 'NumMedia': '0',
+        }
+        webhook_user = self.env.ref('connect.user_connect_webhook')
+        with patch.object(type(self.env['oduist.license']), 'check_license', return_value=True), \
+             patch.object(type(self.env['connect.settings']), 'get_param', side_effect=_gp):
+            Msg.with_user(webhook_user).receive(params)
+        new = Msg.search([('message_sid', '=', 'SMcopy')])
+        # Copy landed on the partner's own record...
+        self.assertTrue(new.mail_message_id, 'inbound from known partner must copy to chatter')
+        self.assertEqual(new.mail_message_id.model, 'res.partner')
+        self.assertEqual(new.mail_message_id.res_id, cust.id)
+        # ...and was also mirrored into the Discuss channel.
+        self.assertTrue(new.channel_id)
+        self.assertTrue(new.channel_message_id)
+
+    def test_outbound_from_chatter_mirrors_to_existing_thread(self):
+        """Outbound sent from a record's chatter is mirrored into the existing
+        Discuss thread when one exists."""
+        from unittest.mock import patch
+        number = '+12125550150'
+        cust = self.env['res.partner'].create({'name': 'Out Cust', 'phone': number})
+        self.assertTrue(cust.phone_sanitized, 'precondition: number must sanitize')
+        ch = self.Channel._get_connect_channel(cust, number=number, create_if_not_found=True)
+
+        class _Fake:
+            sid = 'SMch'; account_sid = 'ACtest'; messaging_service_sid = False
+            num_media = 0; error_code = None; error_message = None
+        with patch.object(type(self.env['connect.message']), 'client_send', return_value=_Fake()):
+            msg = self.env['connect.message'].with_user(self.agent).send(
+                number, 'from chatter', res_id=cust.id, res_model='res.partner',
+                outgoing_callerid='+15550000000')
+        self.assertEqual(msg.channel_id, ch, 'outbound must mirror into the existing thread')
+        self.assertTrue(msg.channel_message_id)
+        self.assertIn(msg.channel_message_id, ch.message_ids)
+
+    def test_outbound_from_chatter_no_thread_no_mirror(self):
+        """Outbound from chatter must NOT create a Discuss thread when none exists."""
+        from unittest.mock import patch
+        number = '+12125550151'
+        cust = self.env['res.partner'].create({'name': 'Cold Cust', 'phone': number})
+        self.assertTrue(cust.phone_sanitized, 'precondition: number must sanitize')
+
+        class _Fake:
+            sid = 'SMnt'; account_sid = 'ACtest'; messaging_service_sid = False
+            num_media = 0; error_code = None; error_message = None
+        with patch.object(type(self.env['connect.message']), 'client_send', return_value=_Fake()):
+            msg = self.env['connect.message'].with_user(self.agent).send(
+                number, 'cold outbound', res_id=cust.id, res_model='res.partner',
+                outgoing_callerid='+15550000000')
+        self.assertFalse(msg.channel_id, 'no existing thread -> must not create/mirror')
+        self.assertFalse(self.Channel.search([
+            ('channel_type', '=', 'connect_messages'),
+            ('connect_partner_id', '=', cust.id)]))
+
+    def test_connect_sidebar_category_open_setting_persists(self):
+        """The 'Messages' sidebar category needs a real res.users.settings field
+        so its collapse/expand toggle reads and persists (like channel/chat)."""
+        Settings = self.env['res.users.settings']
+        self.assertIn('is_discuss_sidebar_category_connect_messages_open', Settings._fields)
+        s = Settings._find_or_create_for_user(self.agent)
+        self.assertTrue(s.is_discuss_sidebar_category_connect_messages_open, 'defaults to open')
+        s.set_res_users_settings(
+            {'is_discuss_sidebar_category_connect_messages_open': False})
+        self.assertFalse(s.is_discuss_sidebar_category_connect_messages_open)
+
+    def test_archive_then_inbound_resurfaces(self):
+        """Archiving unpins the agent's member; a new inbound re-pins it."""
+        ch = self.Channel._get_connect_channel(
+            self.partner, number='+15551230000', create_if_not_found=True)
+        members = (
+            ch.channel_member_ids
+            if release.version_info[0] >= 17
+            else ch.channel_last_seen_partner_ids
         )
-        member = channel.channel_last_seen_partner_ids.filtered(
-            lambda rec: rec.partner_id == self.env.user.partner_id)
-        member.write({
-            'is_pinned': True,
-            'last_interest_dt': fields.Datetime.now() - timedelta(days=2),
+        member = members.filtered(
+            lambda m: m.partner_id == self.agent.partner_id)
+        self.assertTrue(member.is_pinned, 'precondition: thread starts pinned')
+        # Agent archives (unpins) the thread.
+        if release.version_info[0] >= 17:
+            ch.with_user(self.agent).channel_pin(pinned=False)
+            member.invalidate_recordset(['is_pinned', 'unpin_dt'])
+        else:
+            ch.with_user(self.agent).channel_pin(False)
+            member.invalidate_cache(['is_pinned'], member.ids)
+        self.assertFalse(member.is_pinned, 'archive must unpin the agent member')
+        # A new inbound un-archives (re-pins) it.
+        cmsg = self._make_incoming('back again')
+        ch._connect_post_inbound(cmsg)
+        if release.version_info[0] >= 17:
+            member.invalidate_recordset(['is_pinned', 'unpin_dt'])
+        else:
+            member.invalidate_cache(['is_pinned'], member.ids)
+        self.assertTrue(member.is_pinned, 'new message must un-archive (re-pin) the thread')
+
+    def test_inbound_reply_quotes_parent_in_discuss(self):
+        """A customer reply (WhatsApp OriginalRepliedMessageSid) quotes the parent
+        message's Discuss mirror via parent_id."""
+        from unittest.mock import patch
+        Msg = self.env['connect.message']
+        number = '+12125550160'
+        our = '+15550000000'
+        cust = self.env['res.partner'].create({'name': 'Reply Cust', 'phone': number})
+        self.assertTrue(cust.phone_sanitized, 'precondition: number must sanitize')
+        ch = self.Channel._get_connect_channel(
+            cust, number=number, provider='whatsapp', create_if_not_found=True)
+        # Earlier outbound, mirrored into the Discuss thread.
+        parent = Msg.sudo().create({
+            'message_sid': 'WAparent', 'from_number': our, 'to_number': number,
+            'body': 'Goes here', 'message_type': 'whatsapp', 'status': 'sent',
+            'res_model': 'res.partner', 'res_id': cust.id, 'sender_user': self.agent.id,
         })
-        self.env['mail.channel.partner']._gc_unpin_connect_channels()
-        self.assertFalse(member.is_pinned)
+        parent_mirror = ch._connect_post_outbound(parent)
+        self.assertEqual(parent.channel_message_id, parent_mirror)
+
+        def _gp(key, *a, **k):
+            return 'ACtest' if key == 'account_sid' else ''
+        params = {
+            'AccountSid': 'ACtest', 'SmsStatus': 'received',
+            'From': 'whatsapp:' + number, 'To': 'whatsapp:' + our,
+            'Body': 'Reply', 'MessageSid': 'WAreply', 'NumMedia': '0',
+            'OriginalRepliedMessageSid': 'WAparent',
+        }
+        webhook_user = self.env.ref('connect.user_connect_webhook')
+        with patch.object(type(self.env['oduist.license']), 'check_license', return_value=True), \
+             patch.object(type(self.env['connect.settings']), 'get_param', side_effect=_gp):
+            Msg.with_user(webhook_user).receive(params)
+        new = Msg.search([('message_sid', '=', 'WAreply')])
+        self.assertEqual(new.parent_message, parent, 'reply must link the parent connect.message')
+        self.assertTrue(new.channel_message_id)
+        self.assertEqual(new.channel_message_id.parent_id, parent_mirror,
+                         "Discuss mirror must quote the parent's mirror (reply)")

--- a/connect/tests/test_connect_discuss_channel.py
+++ b/connect/tests/test_connect_discuss_channel.py
@@ -482,7 +482,7 @@ class TestConnectDiscussChannel(TransactionCase):
             ch.with_user(self.agent).channel_pin(pinned=False)
             member.invalidate_recordset(['is_pinned', 'unpin_dt'])
         else:
-            ch.with_user(self.agent).channel_pin(False)
+            self.Channel.with_user(self.agent).channel_pin(ch.uuid, pinned=False)
             member.invalidate_cache(['is_pinned'], member.ids)
         self.assertFalse(member.is_pinned, 'archive must unpin the agent member')
         # A new inbound un-archives (re-pins) it.

--- a/connect/views/message.xml
+++ b/connect/views/message.xml
@@ -31,7 +31,7 @@
                 <filter string="Has Error" name="has_error" domain="[('has_error', '=', True)]"/>
                 <filter string="SMS" name="sms" domain="[('message_type', '=', 'sms')]"/>
                 <filter string="MMS" name="mms" domain="[('message_type', '=', 'mms')]"/>
-                <filter string="WhatsApp" name="whatsapp" domain="[('message_type', '=', 'WhatsApp')]"/>
+                <filter string="WhatsApp" name="whatsapp" domain="[('message_type', '=', 'whatsapp')]"/>
                 <separator/>
                 <filter string="With Media" name="with_media" domain="[('num_media', '>', 0)]"/>
                 <separator/>

--- a/connect_elevenlabs/controllers/calendar.py
+++ b/connect_elevenlabs/controllers/calendar.py
@@ -78,6 +78,7 @@ class CalendarController(http.Controller):
             "start": current_start,
             "stop": day_end
         })
+        print(free_intervals)
         return free_intervals
 
     @http.route('/connect_elevenlabs/create_event', methods=['POST'], type=route_type, auth='public',
@@ -161,5 +162,5 @@ class CalendarController(http.Controller):
             event.unlink()
             return {'status': 200, 'detail': 'Event successfully removed'}
         except Exception as e:
-            logger.error('Error removing event %s: %s', event_id, e)
-            return {'status': 500, 'detail': 'Error removing event: %s' % e}
+            logger.error(f'Error removing event {event_id}: {str(e)}')
+            return {'status': 500, 'detail': f'Error removing event: {str(e)}'}

--- a/connect_elevenlabs/controllers/calendar.py
+++ b/connect_elevenlabs/controllers/calendar.py
@@ -5,6 +5,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
+from werkzeug.exceptions import Unauthorized
+
 from odoo import http, release
 
 logger = logging.getLogger(__name__)
@@ -12,12 +14,35 @@ route_type = "json" if release.version_info[0] < 19.0 else 'jsonrpc'
 
 class CalendarController(http.Controller):
 
-    @http.route('/connect_elevenlabs/get_available_slots/<int:user_id>', methods=['POST'], type=route_type, auth='public',
+    def check_tool_token(self):
+        token = http.request.httprequest.headers.get('x-elevenlabs-agent-token')
+        if not token:
+            logger.warning('Tool token check failed: no x-elevenlabs-agent-token header in request')
+            return False
+        expected_token = http.request.env['connect.settings'].sudo().get_param('elevenlabs_agent_token')
+        if not expected_token:
+            logger.warning('Tool token check failed: elevenlabs_agent_token is not configured in settings')
+            return False
+        if token != expected_token:
+            logger.warning('Tool token check failed: token mismatch (received %s...)', token[:8])
+            return False
+        logger.info('Tool token check passed')
+        return True
+
+    @http.route('/connect_elevenlabs/get_available_slots', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
-    def get_available_slots(self, user_id):
+    def get_available_slots(self):
+        logger.info('Incoming request: /connect_elevenlabs/get_available_slots')
+        if not self.check_tool_token():
+            raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
+        user_id = kwargs.get('user_id')
         if kwargs.get('timezone'):
-            user_timezone = timezone(timedelta(hours=int(kwargs.get('timezone'))))
+            tz_val = kwargs['timezone']
+            try:
+                user_timezone = ZoneInfo(tz_val)
+            except (KeyError, ValueError):
+                user_timezone = timezone(timedelta(hours=int(tz_val)))
         else:
             user = http.request.env['res.users'].sudo().browse(user_id)
             tz = user.partner_id.tz
@@ -28,8 +53,8 @@ class CalendarController(http.Controller):
             date = datetime.strptime(kwargs.get('start'), '%Y-%m-%d').replace(tzinfo=user_timezone)
         else:
             current_date = datetime.now().date() + timedelta(days=1)
-            date = current_date.strftime('%Y-%m-%d')
-        date.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+            date = datetime.combine(current_date, datetime.min.time()).replace(tzinfo=user_timezone)
+        date = date.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
 
         end_date = date + timedelta(days=1)
 
@@ -55,12 +80,20 @@ class CalendarController(http.Controller):
         })
         return free_intervals
 
-    @http.route('/connect_elevenlabs/create_event/<int:user_id>', methods=['POST'], type=route_type, auth='public',
+    @http.route('/connect_elevenlabs/create_event', methods=['POST'], type=route_type, auth='public',
                 csrf=False)
-    def create_event(self, user_id):
+    def create_event(self):
+        logger.info('Incoming request: /connect_elevenlabs/create_event')
+        if not self.check_tool_token():
+            raise Unauthorized()
         kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
+        user_id = kwargs.get('user_id')
         if kwargs.get('timezone'):
-            user_timezone = timezone(timedelta(hours=int(kwargs.get('timezone'))))
+            tz_val = kwargs['timezone']
+            try:
+                user_timezone = ZoneInfo(tz_val)
+            except (KeyError, ValueError):
+                user_timezone = timezone(timedelta(hours=int(tz_val)))
         else:
             user = http.request.env['res.users'].sudo().browse(user_id)
             tz = user.partner_id.tz
@@ -90,4 +123,43 @@ class CalendarController(http.Controller):
 
     @http.route('/connect_elevenlabs/get_current_date', methods=['POST'], type=route_type, auth='public', csrf=False)
     def get_current_date(self):
+        logger.info('Incoming request: /connect_elevenlabs/get_current_date')
+        if not self.check_tool_token():
+            raise Unauthorized()
         return {'current_date': str(datetime.now())}
+
+    @http.route('/connect_elevenlabs/get_meetings', methods=['POST'], type=route_type, auth='public',
+                csrf=False)
+    def get_meetings(self):
+        logger.info('Incoming request: /connect_elevenlabs/get_meetings')
+        if not self.check_tool_token():
+            raise Unauthorized()
+        kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
+        partner_id = kwargs.get('partner_id')
+        if not partner_id:
+            return {'status': 400, 'detail': 'partner_id is required'}
+        events = http.request.env['calendar.event'].sudo().search(
+            [('attendee_ids.partner_id', '=', partner_id)],
+            order='start desc'
+        ).read(['id', 'name', 'start', 'stop', 'user_id', 'location', 'description'])
+        return {'status': 200, 'meetings': events}
+
+    @http.route('/connect_elevenlabs/remove_meeting', methods=['POST'], type=route_type, auth='public',
+                csrf=False)
+    def remove_meeting(self):
+        logger.info('Incoming request: /connect_elevenlabs/remove_meeting')
+        if not self.check_tool_token():
+            raise Unauthorized()
+        kwargs = json.loads(http.request.httprequest.get_data(as_text=True))
+        event_id = kwargs.get('event_id')
+        if not event_id:
+            return {'status': 400, 'detail': 'event_id is required'}
+        try:
+            event = http.request.env['calendar.event'].sudo().browse(event_id)
+            if not event.exists():
+                return {'status': 404, 'detail': 'Event not found'}
+            event.unlink()
+            return {'status': 200, 'detail': 'Event successfully removed'}
+        except Exception as e:
+            logger.error('Error removing event %s: %s', event_id, e)
+            return {'status': 500, 'detail': 'Error removing event: %s' % e}

--- a/connect_elevenlabs/hooks.py
+++ b/connect_elevenlabs/hooks.py
@@ -3,7 +3,7 @@ import logging
 import os
 from xml.etree import ElementTree as ET
 
-from odoo import api
+from odoo import api, release
 from odoo.api import SUPERUSER_ID
 
 _logger = logging.getLogger(__name__)
@@ -14,17 +14,17 @@ _TABLE = 'connect_elevenlabs_agent_tool'
 
 
 def _env_from_args(args):
-    """Resolve an Environment from pre_init_hook arguments across Odoo versions.
+    """Resolve an Environment from hook arguments across Odoo versions.
 
-    Odoo 17+ calls ``pre_init_hook(env)``; Odoo <= 16 calls ``pre_init_hook(cr)``
-    with a bare cursor. Detect the type instead of the argument count so a single
-    cursor argument is never mistaken for an Environment (which would otherwise
-    break the install path on Odoo 15 and 16).
+    Modern Odoo passes an Environment; legacy Odoo passes a cursor (and may
+    also pass a registry). Keep this branch in the shared Python implementation.
     """
-    obj = args[0]
-    if isinstance(obj, api.Environment):
-        return obj
-    return api.Environment(obj, SUPERUSER_ID, {})
+    if release.version_info[0] >= 17:
+        return args[0]
+    cursor = args[0]
+    if isinstance(cursor, api.Environment):
+        return cursor
+    return api.Environment(cursor, SUPERUSER_ID, {})
 
 
 def _seed_tool_xmlids():

--- a/connect_elevenlabs_sale/controllers/main.py
+++ b/connect_elevenlabs_sale/controllers/main.py
@@ -2,6 +2,9 @@
 
 import json
 import logging
+
+from werkzeug.exceptions import Unauthorized
+
 from odoo import http, release
 from odoo.addons.connect_elevenlabs.controllers.main import ConnectElevenlabsController
 
@@ -17,7 +20,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/create_partner', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def create_partner(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         call = http.request.env['connect.call'].sudo().browse(int(data['call_id']))
@@ -42,7 +46,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/get_products', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def get_products(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         products = http.request.env['product.template'].sudo().search([])
@@ -61,7 +66,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/create_order', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def create_order(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         # Create the sale order
@@ -93,7 +99,8 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/get_order', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def get_order(self):
-        self.check_agent_request()
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
         logger.info('Agent data: %s', data)
         call = http.request.env['connect.call'].sudo().browse(int(data['call_id']))
@@ -135,8 +142,9 @@ class ConnectElevenlabsSaleController(ConnectElevenlabsController):
     @http.route('/connect_elevenlabs_sale/get_orders', methods=['POST'], type=route_type,
                 auth='public', csrf=False)
     def get_orders(self):
+        if not self.check_tool_token():
+            raise Unauthorized()
         data = json.loads(http.request.httprequest.get_data(as_text=True))
-        self.check_agent_request()
         logger.info('Agent data: %s', data)
         call = http.request.env['connect.call'].sudo().browse(int(data['call_id']))
         if call.direction == 'outgoing':


### PR DESCRIPTION
## Summary
- backport direct SMS, MMS, and WhatsApp conversations into Odoo 15 Discuss
- keep shared Python aligned with 19.0 through explicit Odoo API version branches
- backport Twilio recording callback and ElevenLabs tool authentication updates
- keep the connect Twilio WebRTC phone disabled

## Validation
- clean install and module upgrades succeeded on Odoo 15 in Oduflow
- all 29 backported Discuss tests pass
- backend JS and QWeb bundles compile and load; Messages category renders in Discuss
- compileall, XML validation, and diff checks pass

## Known baseline
The existing S3 URL test still expects a bucket name without the configured `oduist-connect-` prefix (31/32 total tests pass). The same test and implementation already exist on both source branches and are unrelated to this backport.