### PR TITLE
[connect_elevenlabs] fix AttributeError on agent write

### DIFF
--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -235,8 +235,6 @@ class ElevenlabsAgent(models.Model):
                 )
         if not self.env.context.get("skip_elevenlabs"):
             self.update_elevenlabs_agent()
-            if not self.knowledge_base_note and self.knowledge_base_id:
-                self.delete_elevenlabs_knowledge_base()
         return res
 
     def unlink(self):


### PR DESCRIPTION
`ElevenlabsAgent.write()` referenced `self.knowledge_base_note` / `self.knowledge_base_id` and called `delete_elevenlabs_knowledge_base()`. None of these exist on the model — no field, no method, nowhere in the repo or on any branch.

Result: every `write()` on `connect.elevenlabs_agent` without the `skip_elevenlabs` context raised `AttributeError` after the ElevenLabs sync and rolled the transaction back.

Removes the dead branch. Backports to 15.0–18.0 follow.