### PR TITLE
[18.0][connect_elevenlabs] fix AttributeError on agent write

### DIFF
--- a/connect_elevenlabs/models/agent.py
+++ b/connect_elevenlabs/models/agent.py
@@ -235,8 +235,6 @@ class ElevenlabsAgent(models.Model):
                 )
         if not self.env.context.get("skip_elevenlabs"):
             self.update_elevenlabs_agent()
-            if not self.knowledge_base_note and self.knowledge_base_id:
-                self.delete_elevenlabs_knowledge_base()
         return res
 
     def unlink(self):


### PR DESCRIPTION
Backport of #145 to 18.0.

`ElevenlabsAgent.write()` referenced `self.knowledge_base_note` / `self.knowledge_base_id` and called `delete_elevenlabs_knowledge_base()` — none of which exist on the model. Every `write()` without the `skip_elevenlabs` context raised `AttributeError` and rolled the transaction back.